### PR TITLE
[Feat] 모임 생성 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -34,6 +34,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             log.info("요청 URI: {}, accessToken: {}", requestURI, accessToken);
             log.info("refreshToken: {}", refreshToken);
 
+            // 예외 경로 설정 (로그인, 회원가입 등)
+            if (isExcludedPath(requestURI)) {
+                filterChain.doFilter(request, response); // 필터를 건너뜀
+                return;
+            }
+
             // 로그아웃 요청 처리
             if ("/api/auths/signout".equals(requestURI)) {
                 if (!validateLogoutRequest(accessToken, refreshToken, response)) {
@@ -44,7 +50,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             // 일반 요청 처리
-            if (accessToken != null) {
+            if (accessToken == null || accessToken.isEmpty()) {
+                log.warn("accessToken이 존재하지 않습니다.");
+                sendErrorResponse(response, "accessToken이 요청에 포함되지 않았습니다.", HttpStatus.BAD_REQUEST);
+                return;
+            }
+
+            else {
                 // 1. accessToken이 블랙리스트에 포함되어 있는지 확인
                 if (tokenBlacklistService.isBlacklisted(accessToken)) {
                     sendErrorResponse(response, "이미 로그아웃된 토큰입니다. 로그인 후 다시 시도해주세요.", HttpStatus.UNAUTHORIZED);
@@ -112,6 +124,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         ErrorResponse errorResponse = new ErrorResponse(false, message, httpStatus);
         response.getWriter().write(new ObjectMapper().writeValueAsString(errorResponse));
+    }
+
+    private boolean isExcludedPath(String requestURI) {
+        return requestURI.startsWith("/api/auths/check-email") ||
+                requestURI.startsWith("/api/auths/signin") ||
+                requestURI.startsWith("/api/auths/signup");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/category/entity/Category.java
+++ b/src/main/java/com/wemo/backend/domain/category/entity/Category.java
@@ -1,4 +1,24 @@
 package com.wemo.backend.domain.category.entity;
 
+import jakarta.persistence.*;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_CATEGORY")
 public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id", nullable = false)
+    @Comment("카테고리 id")
+    private Long id;
+
+    @Column(name = "parent_id")
+    @Comment("상위 카테고리 id")
+    private Long parentId;
+
+    @Column(name = "category_name", nullable = false)
+    @Comment("카테고리 이름")
+    private String categoryName;
+
 }

--- a/src/main/java/com/wemo/backend/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/wemo/backend/domain/category/repository/CategoryRepository.java
@@ -1,4 +1,7 @@
 package com.wemo.backend.domain.category.repository;
 
-public interface CategoryRepository {
+import com.wemo.backend.domain.category.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
 }

--- a/src/main/java/com/wemo/backend/domain/image/dto/ImageCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/image/dto/ImageCreateRequest.java
@@ -1,4 +1,0 @@
-package com.wemo.backend.domain.image.dto;
-
-public class ImageCreateRequest {
-}

--- a/src/main/java/com/wemo/backend/domain/image/entity/Image.java
+++ b/src/main/java/com/wemo/backend/domain/image/entity/Image.java
@@ -1,4 +1,58 @@
 package com.wemo.backend.domain.image.entity;
 
-public class Image {
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_IMAGE")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Image extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "image_id", nullable = false)
+    @Comment("이미지 id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)  // 이미지와 사용자 관계 설정 (다대일)
+    @JoinColumn(name = "user_id", nullable = false)  // user_id 외래키 설정
+    @Comment("유저 id")
+    private User user;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(name = "entity_type", nullable = false)
+    @Comment("엔티티 타입")
+    private EntityType entityType;
+
+    @Column(name = "entity_id", nullable = false)
+    @Comment("엔티티 id")
+    private Long entityId;
+
+    @Column(name = "file_url", nullable = false)
+    @Comment("이미지 url")
+    private String fileUrl;
+
+    public enum EntityType {
+
+        PROFILE("유저 프로필"),
+        MEETING("모임"),
+        PLAN("일정"),
+        REVIEW("후기");
+
+        private String entityType;
+
+        EntityType(String entityType) {
+            this.entityType = entityType;
+        }
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
@@ -1,4 +1,7 @@
 package com.wemo.backend.domain.image.repository;
 
-public interface ImageRepository {
+import com.wemo.backend.domain.image.entity.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.image.service;
+
+import com.wemo.backend.domain.user.entity.User;
+
+public interface ImageStore {
+
+    void storeMeetingImage(User user, Long meetingId, String fileUrl);
+
+}

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
@@ -1,0 +1,28 @@
+package com.wemo.backend.domain.image.service;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.repository.ImageRepository;
+import com.wemo.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageStoreImpl implements ImageStore {
+
+    private final ImageRepository imageRepository;
+
+    @Override
+    public void storeMeetingImage(User user, Long meetingId, String fileUrl) {
+
+        Image image = Image.builder()
+                .user(user)
+                .entityType(Image.EntityType.MEETING)
+                .entityId(meetingId)
+                .fileUrl(fileUrl)
+                .build();
+
+        imageRepository.save(image);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -1,4 +1,42 @@
 package com.wemo.backend.domain.meeting.controller;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
+import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.service.MeetingService;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Meetings")
+@RestController
+@RequestMapping("/api/meetings")
+@RequiredArgsConstructor
 public class MeetingController {
+
+    private final MeetingService meetingService;
+
+    @Operation(summary = "모임 생성", description = "모임을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "모임이 생성되었습니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+    })
+    @RequestMapping(value = "", method = RequestMethod.POST)
+    public ResponseEntity<SuccessResponse<String>> createMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                 @Valid @RequestBody MeetingCreateRequest request) {
+        meetingService.createMeeting(userDetails.getUsername(), request);
+        return ResponseEntity.status(201).body(SuccessResponse.successWithNoData("모임 생성 성공"));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateRequest.java
@@ -1,4 +1,26 @@
 package com.wemo.backend.domain.meeting.dto;
 
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class MeetingCreateRequest {
+
+    @NotBlank(message = "모임명은 필수 입력 값입니다.")
+    @Size(min = 2, max = 30, message = "모임명은 2자 이상 30자 이하입니다.")
+    private String meetingName;
+
+    @Size(min = 8, max = 500, message = "모임 설명은 8자 이상 500자 이하입니다.")
+    private String description;
+
+    @NotNull(message = "카테고리 id는 필수 입력 값입니다.")
+    // @PositiveOrZero : 값이 양수 또는 0인지 검증
+    @PositiveOrZero(message = "카테고리 id는 양수 값이어야 합니다.")
+    private Long categoryId;
+
+    @NotBlank(message = "모임 대표 이미지는 필수 입력 값입니다.")
+    private String fileUrl;
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/entity/Meeting.java
@@ -1,4 +1,45 @@
 package com.wemo.backend.domain.meeting.entity;
 
-public class Meeting {
+import com.wemo.backend.domain.category.entity.Category;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_MEETING")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Meeting extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_id", nullable = false)
+    @Comment("모임 id")
+    private Long id;
+
+    @Column(name = "meeting_name", nullable = false)
+    @Comment("모임명")
+    private String meetingName;
+
+    @Column(name = "description")
+    @Comment("모임설명")
+    private String description;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id") // 외래 키 컬럼 이름을 명시적으로 지정
+    @Comment("카테고리 id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @Comment("유저 id")
+    private User user;
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
@@ -1,4 +1,7 @@
 package com.wemo.backend.domain.meeting.repository;
 
-public interface MeetingRepository {
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -1,4 +1,11 @@
 package com.wemo.backend.domain.meeting.service;
 
+import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import org.springframework.stereotype.Service;
+
+@Service
 public interface MeetingService {
+
+    void createMeeting(String email, MeetingCreateRequest request);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -1,4 +1,40 @@
 package com.wemo.backend.domain.meeting.service;
 
-public class MeetingServiceImpl {
+import com.wemo.backend.domain.image.service.ImageStore;
+import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.domain.user.service.UserReader;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingServiceImpl implements MeetingService {
+
+    private final UserReader userReader;
+    private final MeetingStore meetingStore;
+    private final ImageStore imageStore;
+
+    /**
+     * 0. 모임 생성
+     *
+     * @param email 이메일
+     * @param request 모임 생성 데이터 (모임명, 모임 설명, 카테고리, 모임 이미지)
+     */
+    @Override
+    @Transactional
+    public void createMeeting(String email, MeetingCreateRequest request) {
+        // 유저 객체 검증
+        User userByEmail = userReader.getUserByEmail(email);
+
+        // 모임 객체 저장
+        Meeting meeting = meetingStore.storeMeeting(request, userByEmail);
+
+        // 모임 대표 이미지 저장
+        imageStore.storeMeetingImage(userByEmail, meeting.getId(), request.getFileUrl());
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStore.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStore.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.entity.User;
+
+public interface MeetingStore {
+
+    Meeting storeMeeting(MeetingCreateRequest request, User user);
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStoreImpl.java
@@ -1,0 +1,44 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.category.entity.Category;
+import com.wemo.backend.domain.category.repository.CategoryRepository;
+import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.repository.MeetingRepository;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.exception.CustomException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_CATEGORY_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingStoreImpl implements MeetingStore {
+
+    private final CategoryRepository categoryRepository;
+
+    private final MeetingRepository meetingRepository;
+
+    @Override
+    @Transactional
+    public Meeting storeMeeting(MeetingCreateRequest request, User user) {
+
+        Category category = categoryRepository.findById(request.getCategoryId()).orElseThrow(
+                () -> new CustomException(ILLEGAL_CATEGORY_NOT_FOUND)
+        );
+
+        Meeting meeting = Meeting.builder()
+                .meetingName(request.getMeetingName())
+                .description(request.getDescription())
+                .category(category)
+                .user(user)
+                .build();
+
+        meetingRepository.save(meeting);
+
+        return meeting;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
@@ -2,9 +2,11 @@ package com.wemo.backend.domain.user.dto;
 
 import com.wemo.backend.domain.user.entity.User;
 import lombok.Builder;
+import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+@Getter
 @Builder
 public class UserInfoResponse {
 

--- a/src/main/java/com/wemo/backend/domain/user/entity/LoginType.java
+++ b/src/main/java/com/wemo/backend/domain/user/entity/LoginType.java
@@ -7,10 +7,10 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum LoginType {
 
-    GENERAL("일반유저"),
-    KAKAO("카카오유저"),
-    GOOGLE("구글유저"),
-    NAVER("네이버유저");
+    GENERAL("일반"),
+    KAKAO("카카오"),
+    GOOGLE("구글"),
+    NAVER("네이버");
 
     private final String userType;
 

--- a/src/main/java/com/wemo/backend/domain/user/entity/User.java
+++ b/src/main/java/com/wemo/backend/domain/user/entity/User.java
@@ -20,32 +20,32 @@ public class User extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "USER_ID", nullable = false)
+    @Column(name = "user_id", nullable = false)
     @Comment("유저 id")
     private UUID id;
 
-    @Column(name = "EMAIL", nullable = false, unique = true)
+    @Column(name = "email", nullable = false, unique = true)
     @Comment("이메일")
     private String email;
 
-    @Column(name = "COMPANY_NAME", nullable = false)
+    @Column(name = "company_name", nullable = false)
     @Comment("회사명")
     private String companyName;
 
-    @Column(name = "NICKNAME", nullable = false)
+    @Column(name = "nickname", nullable = false)
     @Comment("닉네임")
     private String nickname;
 
-    @Column(name = "PASSWORD", nullable = false)
+    @Column(name = "password", nullable = false)
     @Comment("비밀번호")
     private String password;
 
-    @Column(name = "PROFILE_IMAGE_PATH", nullable = false)
+    @Column(name = "profile_image_path", nullable = false)
     @Comment("프로필 이미지")
     private String profileImagePath;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "LOGIN_TYPE")
+    @Column(name = "login_type")
     private LoginType loginType;
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -36,6 +36,7 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public void checkEmail(String email) {
+
         // 사용자 아이디 중복 검사
         userReader.checkEmailValid(email);
     }
@@ -80,7 +81,9 @@ public class UserServiceImpl implements UserService {
      * @return 응답 메세지
      */
     @Override
+    @Transactional
     public String signout(String accessToken, String refreshToken) {
+
         // Bearer 제거
         String cleanToken = accessToken.replace("Bearer ", "");
 

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -7,12 +7,15 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // user
-    ILLEGAL_EMAIL_DUPLICATION(HttpStatus.CONFLICT, "사용 중인 이메일 입니다."),
+    ILLEGAL_EMAIL_DUPLICATION(HttpStatus.CONFLICT, "이미 사용 중인 이메일 입니다."),
     ILLEGAL_PASSWORD_NOT_VALID(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     ILLEGAL_USER_NOT_EXIST(HttpStatus.BAD_REQUEST, "가입되지 않은 아이디입니다."),
 
     // token
-    ILLEGAL_REFRESH_TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 refreshToken 입니다.");
+    ILLEGAL_REFRESH_TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 refreshToken 입니다."),
+
+    // category
+    ILLEGAL_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,16 +10,23 @@ spring:
     username: ${DB_USER}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+
   jpa:
     hibernate:
       ddl-auto: update
+      # 테이블명 설정
+      naming:
+        physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     show-sql: true
     # SQL 문 포맷 설정
     properties:
       hibernate:
         format_sql: true
+  sql:
+    init:
+      data-locations: classpath:category.sql
+      mode: never
 
 logging:
   level:
     org.hibernate.SQL: debug
-

--- a/src/main/resources/category.sql
+++ b/src/main/resources/category.sql
@@ -1,0 +1,14 @@
+-- TB_CATEGORY 테이블 생성
+CREATE TABLE IF NOT EXISTS TB_CATEGORY (
+                                           category_id INT AUTO_INCREMENT PRIMARY KEY COMMENT '카테고리 id',
+                                           parent_id INT NULL COMMENT '상위 카테고리 id',
+                                           category_name VARCHAR(255) NOT NULL COMMENT '카테고리 이름',
+    FOREIGN KEY (parent_id) REFERENCES TB_CATEGORY(category_id) ON DELETE CASCADE
+    );
+
+-- 초기 데이터 삽입
+INSERT INTO TB_CATEGORY (category_id, parent_id, category_name) VALUES
+                                                                    (1, NULL, '달램핏'),
+                                                                    (2, NULL, '워케이션'),
+                                                                    (3, 1, '오피스 스트레칭'),
+                                                                    (4, 1, '마인드풀니스');


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 생성 기능 구현하였습니다.
- 모임 생성을 위해 카테고리, 이미지 테이블을 생성하였으며, 추후 관리의 용이성을 위해 해당 테이블을 분리하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/meeting-create-8 -> dev
- close #8 

<br/>

## 🔥 트러블 슈팅 (선택)
### 문제 1: 회원 정보 조회 시 오류 발생 (HttpMessageConversionException)
- 원인: 반환 객체인 UserInfoResponse의 JSON 직렬화 과정에서 문제 발생
- 해결: UserInfoResponse 클래스에 @Getter를 추가하여 JSON 직렬화 문제를 해결

### 문제 2: 요청 헤더에 토큰 미존재 시 명확한 예외 메시지 반환되지 않음
- 원인: 필터에서 토큰이 없을 경우에 대한 예외 처리가 부족했음
- 해결: 필터 단에서 조건문을 추가하여 상황에 맞는 응답 메시지를 반환하도록 수정
---
### 추후 고민할 내용
- Flyway 를 사용하여 DB 관리 (카테고리 테이블 관련)
- 필터의 조건문 리팩토링 (성능 개선을 위함)