### PR TITLE
[Feat] 일정 생성 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// Swagger (API 문서화)
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 
 	// 검증 관련 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -129,7 +129,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean isExcludedPath(String requestURI) {
         return requestURI.startsWith("/api/auths/check-email") ||
                 requestURI.startsWith("/api/auths/signin") ||
-                requestURI.startsWith("/api/auths/signup");
+                requestURI.startsWith("/api/auths/signup") ||
+                requestURI.startsWith("/swagger-ui/") ||
+                requestURI.startsWith("/swagger-ui.html") ||
+                requestURI.startsWith("/v3/api-docs");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/category/entity/Category.java
+++ b/src/main/java/com/wemo/backend/domain/category/entity/Category.java
@@ -1,10 +1,12 @@
 package com.wemo.backend.domain.category.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(name = "TB_CATEGORY")
+@Getter
 public class Category {
 
     @Id

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
@@ -1,9 +1,10 @@
 package com.wemo.backend.domain.image.service;
 
+import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.user.entity.User;
 
 public interface ImageStore {
 
-    void storeMeetingImage(User user, Long meetingId, String fileUrl);
+    Image storeImage(User user, Long entityId, String fileUrl, Image.EntityType entityType);
 
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
@@ -13,16 +13,18 @@ public class ImageStoreImpl implements ImageStore {
     private final ImageRepository imageRepository;
 
     @Override
-    public void storeMeetingImage(User user, Long meetingId, String fileUrl) {
+    public Image storeImage(User user, Long entityId, String fileUrl, Image.EntityType entityType) {
 
         Image image = Image.builder()
                 .user(user)
-                .entityType(Image.EntityType.MEETING)
-                .entityId(meetingId)
+                .entityType(entityType)
+                .entityId(entityId)
                 .fileUrl(fileUrl)
                 .build();
 
         imageRepository.save(image);
+
+        return image;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+
+public interface MeetingReader {
+
+    Meeting getMeeting(Long meetingId);
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
@@ -1,0 +1,22 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.repository.MeetingRepository;
+import com.wemo.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class MeetingReaderImpl implements MeetingReader {
+
+    private final MeetingRepository meetingRepository;
+
+    public Meeting getMeeting(Long meetingId) {
+        return meetingRepository.findById(meetingId).orElseThrow(
+                () -> new CustomException(ILLEGAL_MEETING_NOT_FOUND)
+        );
+    }
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.meeting.service;
 
+import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.entity.Meeting;
@@ -33,7 +34,7 @@ public class MeetingServiceImpl implements MeetingService {
         Meeting meeting = meetingStore.storeMeeting(request, userByEmail);
 
         // 모임 대표 이미지 저장
-        imageStore.storeMeetingImage(userByEmail, meeting.getId(), request.getFileUrl());
+        imageStore.storeImage(userByEmail, meeting.getId(), request.getFileUrl(), Image.EntityType.MEETING);
 
     }
 

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -1,4 +1,41 @@
 package com.wemo.backend.domain.plan.controller;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
+import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import com.wemo.backend.domain.plan.service.PlanService;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Plans")
+@RestController
+@RequestMapping("/api/plans")
+@RequiredArgsConstructor
 public class PlanController {
+
+    private final PlanService planService;
+
+    @Operation(summary = "일정 생성", description = "일정을 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "일정이 생성되었습니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+    })
+    @RequestMapping(value = "/{meetingId}", method = RequestMethod.POST)
+    public ResponseEntity<SuccessResponse<PlanCreateResponse>> createPlan(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @Valid @RequestBody PlanCreateRequest request,
+                                                                          @PathVariable Long meetingId) {
+
+        return ResponseEntity.status(201).body(SuccessResponse.successWithData(planService.createPlan(userDetails.getUsername(), request, meetingId)));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanCreateRequest.java
@@ -1,4 +1,39 @@
 package com.wemo.backend.domain.plan.dto;
 
+import jakarta.validation.constraints.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class PlanCreateRequest {
+
+    @NotBlank(message = "일정명은 필수 입력 값입니다.")
+    @Size(min = 3, max = 50, message = "일정명은 3자 이상 50자 이내입니다.")
+    private String planName;
+
+    @Size(max = 500, message = "모임 설명은 500자 이내입니다.")
+    private String content;
+
+    @NotBlank(message = "모임 날짜는 필수 입력 값입니다.")
+    private String dateTime;
+
+    @NotBlank(message = "마감 날짜는 필수 입력 값입니다.")
+    private String registrationEnd;
+
+    @NotBlank(message = "주소는 필수 입력 값입니다.")
+    private String address;
+
+    @NotNull(message = "경도는 필수 입력 값입니다.")
+    private double longitude;
+
+    @NotNull(message = "위도는 필수 입력 값입니다.")
+    private double latitude;
+
+    @Min(value = 2, message = "모집 정원은 최소 2명입니다.")
+    @Max(value = 100, message = "모집 정원은 최대 100명입니다.")
+    private int capacity;
+
+    private String fileUrl;
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanCreateResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanCreateResponse.java
@@ -1,0 +1,88 @@
+package com.wemo.backend.domain.plan.dto;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.entity.Plan;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanCreateResponse {
+
+    private Long planId;
+
+    private String planName;
+
+    private String category;
+
+    private String address;
+
+    private double longitude;
+
+    private double latitude;
+
+    private String planImagePath;
+
+    private String content;
+
+    private LocalDateTime dateTime;
+
+    private LocalDateTime registrationEnd;
+
+    private int capacity;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private boolean isOpened;
+
+    private boolean isFulled;
+
+    // 이미지가 있는 경우
+    public static PlanCreateResponse fromEntityWithImage(Plan plan, Meeting meeting, Image image) {
+
+        return PlanCreateResponse.builder()
+                .planId(plan.getId())
+                .planName(plan.getPlanName())
+                .category(meeting.getCategory().getCategoryName())
+                .address(plan.getAddress())
+                .longitude(plan.getLongitude())
+                .latitude(plan.getLatitude())
+                .planImagePath(image.getFileUrl())
+                .content(plan.getContent())
+                .dateTime(plan.getDateTime())
+                .registrationEnd(plan.getRegistrationEnd())
+                .capacity(plan.getCapacity())
+                .createdAt(plan.getCreatedAt())
+                .updatedAt(plan.getUpdatedAt())
+                .isOpened(plan.isOpened())
+                .isFulled(plan.isFulled())
+                .build();
+    }
+
+    // 이미지가 없는 경우
+    public static PlanCreateResponse fromEntity(Plan plan, Meeting meeting) {
+
+        return PlanCreateResponse.builder()
+                .planId(plan.getId())
+                .planName(plan.getPlanName())
+                .category(meeting.getCategory().getCategoryName())
+                .address(plan.getAddress())
+                .longitude(plan.getLongitude())
+                .latitude(plan.getLatitude())
+                .content(plan.getContent())
+                .dateTime(plan.getDateTime())
+                .registrationEnd(plan.getRegistrationEnd())
+                .capacity(plan.getCapacity())
+                .createdAt(plan.getCreatedAt())
+                .updatedAt(plan.getUpdatedAt())
+                .isOpened(plan.isOpened())
+                .isFulled(plan.isFulled())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
@@ -1,4 +1,92 @@
 package com.wemo.backend.domain.plan.entity;
 
-public class Plan {
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "TB_PLAN")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Plan extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "plan_id", nullable = false)
+    @Comment("일정 id")
+    private Long id;
+
+    @Column(name = "plan_name", nullable = false)
+    @Comment("일정명")
+    private String planName;
+
+    @Column(name = "content")
+    @Comment("일정 내용")
+    private String content;
+
+    @Column(name = "date_time", nullable = false)
+    @Comment("모임 날짜")
+    private LocalDateTime dateTime;
+
+    @Column(name = "registration_end", nullable = false)
+    @Comment("마감 날짜")
+    private LocalDateTime registrationEnd;
+
+    @Column(name = "capacity", nullable = false)
+    @Comment("모집 정원")
+    private int capacity;
+
+    @Column(name = "longitude", nullable = false)
+    @Comment("경도")
+    private double longitude;
+
+    @Column(name = "latitude", nullable = false)
+    @Comment("위도")
+    private double latitude;
+
+    @Column(name = "address", nullable = false)
+    @Comment("주소")
+    private String address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "district_id", nullable = false)
+    @Comment("군/구 id")
+    private District district;
+
+    @Column(name = "is_opened", nullable = false)
+    @Comment("개설 확정 여부")
+    @Builder.Default
+    private boolean opened = false;
+
+    @Column(name = "is_canceled", nullable = false)
+    @Comment("취소 여부")
+    @Builder.Default
+    private boolean canceled = false;
+
+    @Column(name = "is_fulled", nullable = false)
+    @Comment("마감 여부")
+    @Builder.Default
+    private boolean fulled = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("유저 id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    @Comment("모임 id")
+    private Meeting meeting;
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -1,4 +1,7 @@
 package com.wemo.backend.domain.plan.repository;
 
-public interface PlanRepository {
+import com.wemo.backend.domain.plan.entity.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -1,4 +1,12 @@
 package com.wemo.backend.domain.plan.service;
 
+import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import org.springframework.stereotype.Service;
+
+@Service
 public interface PlanService {
+
+    PlanCreateResponse createPlan(String email, PlanCreateRequest request, Long meetingId);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -1,4 +1,88 @@
 package com.wemo.backend.domain.plan.service;
 
-public class PlanServiceImpl {
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.service.ImageStore;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.service.MeetingReader;
+import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.region.entity.Province;
+import com.wemo.backend.domain.region.repository.DistrictRepository;
+import com.wemo.backend.domain.region.repository.ProvinceRepository;
+import com.wemo.backend.domain.region.service.RegionServiceImpl;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.domain.user.service.UserReader;
+import com.wemo.backend.global.exception.CustomException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_GRANTED;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PlanServiceImpl implements PlanService {
+
+    private final UserReader userReader;
+
+    private final MeetingReader meetingReader;
+
+    private final ProvinceRepository provinceRepository;
+
+    private final DistrictRepository districtRepository;
+
+    private final ImageStore imageStore;
+
+    private final PlanStore planStore;
+
+    /**
+     * 0. 일정 생성
+     *
+     * @param email 이메일
+     * @param request 일정 생성 요청 데이터
+     * @param meetingId 모임 id
+     * @return 생성된 일정 정보 반환
+     */
+    @Override
+    @Transactional
+    public PlanCreateResponse createPlan(String email, PlanCreateRequest request, Long meetingId) {
+
+        // 유저 객체 검증
+        User user = userReader.getUserByEmail(email);
+
+        // 모임장인지 검증
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+        if (user.getId() != meeting.getUser().getId()) throw new CustomException(ILLEGAL_PLAN_NOT_GRANTED);
+
+        // 주소 저장
+        // Step 1: 주소 파싱
+        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(request.getAddress());
+        String provinceName = parsedAddress.get("province");
+        String districtName = parsedAddress.get("district");
+
+        // Step 2: 시/도 저장 또는 조회
+        Province province = provinceRepository.findByProvinceName(provinceName)
+                .orElseGet(() -> provinceRepository.save(new Province(provinceName)));
+
+        // Step 3: 군/구 저장 또는 조회
+        District district = districtRepository.findByDistrictNameAndProvince(districtName, province)
+                .orElseGet(() -> districtRepository.save(new District(districtName, province)));
+
+        Plan plan = planStore.storePlan(request, district, user, meeting);
+
+        // 이미지 저장 (선택)
+        if (!request.getFileUrl().isEmpty()) {
+            Image image = imageStore.storeImage(user, plan.getId(), request.getFileUrl(), Image.EntityType.PLAN);
+            return PlanCreateResponse.fromEntityWithImage(plan, meeting, image);
+        }
+
+        return PlanCreateResponse.fromEntity(plan, meeting);
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
@@ -1,0 +1,13 @@
+package com.wemo.backend.domain.plan.service;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.user.entity.User;
+
+public interface PlanStore {
+
+    Plan storePlan(PlanCreateRequest request, District district, User user, Meeting meeting);
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -1,0 +1,47 @@
+package com.wemo.backend.domain.plan.service;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.PlanRepository;
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class PlanStoreImpl implements PlanStore{
+
+    private final PlanRepository planRepository;
+
+    @Override
+    @Transactional
+    public Plan storePlan(PlanCreateRequest request, District district, User user, Meeting meeting) {
+
+        Plan plan = Plan.builder()
+                .planName(request.getPlanName())
+                .content(request.getContent())
+                .dateTime(LocalDateTime.parse(request.getDateTime()))
+                .registrationEnd(LocalDateTime.parse(request.getRegistrationEnd()))
+                .capacity(request.getCapacity())
+                .longitude(request.getLongitude())
+                .latitude(request.getLatitude())
+                .address(request.getAddress())
+                .district(district)
+                .opened(false)
+                .canceled(false)
+                .fulled(false)
+                .user(user)
+                .meeting(meeting)
+                .build();
+
+        planRepository.save(plan);
+
+        return plan;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/entity/District.java
+++ b/src/main/java/com/wemo/backend/domain/region/entity/District.java
@@ -1,4 +1,35 @@
 package com.wemo.backend.domain.region.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_DISTRICT")
+@Getter
+@NoArgsConstructor
 public class District {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "district_id", nullable = false)
+    @Comment("군/구 id")
+    private Long id;
+
+    @Column(name = "district_name", nullable = false)
+    @Comment("군/구 이름")
+    private String districtName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "province_id")
+    @Comment("시/도 id")
+    private Province province;
+
+    public District(String districtName, Province province) {
+
+        this.districtName = districtName;
+        this.province = province;
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/entity/Province.java
+++ b/src/main/java/com/wemo/backend/domain/region/entity/Province.java
@@ -1,4 +1,29 @@
 package com.wemo.backend.domain.region.entity;
 
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_PROVINCE")
+@Getter
+@NoArgsConstructor
 public class Province {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "province_id", nullable = false)
+    @Comment("시/도 id")
+    private Long id;
+
+    @Column(name = "province_name", nullable = false, unique = true)
+    @Comment("시/도 이름")
+    private String provinceName;
+
+    public Province(String provinceName) {
+        this.provinceName = provinceName;
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/entity/Region.java
+++ b/src/main/java/com/wemo/backend/domain/region/entity/Region.java
@@ -1,4 +1,0 @@
-package com.wemo.backend.domain.region.entity;
-
-public class Region {
-}

--- a/src/main/java/com/wemo/backend/domain/region/repository/DistrictRepository.java
+++ b/src/main/java/com/wemo/backend/domain/region/repository/DistrictRepository.java
@@ -1,4 +1,13 @@
 package com.wemo.backend.domain.region.repository;
 
-public interface DistrictRepository {
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.region.entity.Province;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DistrictRepository extends JpaRepository<District, Long> {
+
+    Optional<District> findByDistrictNameAndProvince(String districtName, Province province);
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/repository/ProvinceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/region/repository/ProvinceRepository.java
@@ -1,4 +1,12 @@
 package com.wemo.backend.domain.region.repository;
 
-public interface ProvinceRepository {
+import com.wemo.backend.domain.region.entity.Province;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ProvinceRepository extends JpaRepository<Province, Long> {
+
+    Optional<Province> findByProvinceName(String provinceName);
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/repository/RegionRepository.java
+++ b/src/main/java/com/wemo/backend/domain/region/repository/RegionRepository.java
@@ -1,4 +1,0 @@
-package com.wemo.backend.domain.region.repository;
-
-public interface RegionRepository {
-}

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
@@ -1,4 +1,27 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.global.exception.CustomException;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_ADDRESS_NOT_VALID;
+
+@Service
 public class RegionServiceImpl {
+
+    public static Map<String, String> parseAddress(String address) {
+
+        String[] parts = address.split(" ");
+        if (parts.length < 2) {
+            throw new CustomException(ILLEGAL_ADDRESS_NOT_VALID);
+        }
+
+        Map<String, String> addressMap = new HashMap<>();
+        addressMap.put("province", parts[0]); // 시/도
+        addressMap.put("district", parts[1]); // 군/구
+        return addressMap;
+    }
+
 }

--- a/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
@@ -16,7 +16,10 @@ public class SwaggerConfig {
         return new OpenAPI()
                 .components(new Components())
                 .info(apiInfo())
-                .addTagsItem(new Tag().name("Users").description("사용자 관련 API"));
+                .addTagsItem(new Tag().name("Users").description("사용자 관련 API"))
+                .addTagsItem(new Tag().name("Meetings").description("모임 관련 API"))
+                .addTagsItem(new Tag().name("Plans").description("일정 관련 API"));
+
     }
 
     private Info apiInfo() {

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -15,7 +15,14 @@ public enum ErrorCode {
     ILLEGAL_REFRESH_TOKEN_NOT_VALID(HttpStatus.BAD_REQUEST, "유효하지 않은 refreshToken 입니다."),
 
     // category
-    ILLEGAL_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다.");
+    ILLEGAL_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+
+    // meeting
+    ILLEGAL_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
+
+    // plan
+    ILLEGAL_PLAN_NOT_GRANTED(HttpStatus.BAD_REQUEST, "모임장만 일정을 생성할 수 있습니다."),
+    ILLEGAL_ADDRESS_NOT_VALID(HttpStatus.BAD_REQUEST, "주소 값이 유효하지 않습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 생성 기능 구현하였습니다.
- 모임을 생성한 모임장만 일정을 생성할 수 있도록 하였습니다.
- 각 항목별 유효성 검사 처리하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/plan-create-12
- close #12 

<br/>

## 🔥 트러블 슈팅 (선택)
- 문제 : Swagger java.lang.NoSuchMethodError: 'void org.springframework.web.method.ControllerAdviceBean 에러 발생 및 접속되지 않는 오류(500 Internal Server Error)
 -> 해결 : build.gradle에 Swagger의 버전을 기존 2.0.2 에서 2.7.0 버전으로 업그레이드하여 해결

### 추후 수정할 내용
- 모임 날짜와 마감 날짜에 대한 유효성 검사