### PR TITLE
[Feat] 일정 참여 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -48,7 +48,7 @@ public class MeetingServiceImpl implements MeetingService {
      *
      * @param email 이메일
      * @param meetingId 모임 id
-     * @return 성공 메세지 반환
+     * @return 성공 응답 메세지
      */
     @Override
     @Transactional

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingStoreImpl.java
@@ -13,8 +13,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static com.wemo.backend.global.exception.ErrorCode.ALREADY_MEETING_JOINED;
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_CATEGORY_NOT_FOUND;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor
@@ -52,7 +51,7 @@ public class MeetingStoreImpl implements MeetingStore {
 
         boolean alreadyJoined = meetingMemberRepository.existsByUserAndMeeting(user, meeting);
 
-        if (alreadyJoined) throw new CustomException(ALREADY_MEETING_JOINED);
+        if (alreadyJoined) throw new CustomException(ALREADY_JOINED_MEETING);
 
         MeetingMember meetingMember = MeetingMember.builder()
                 .user(user)

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -38,4 +38,16 @@ public class PlanController {
         return ResponseEntity.status(201).body(SuccessResponse.successWithData(planService.createPlan(userDetails.getUsername(), request, meetingId)));
     }
 
+    @Operation(summary = "일정 참여", description = "일정에 참여합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "일정에 참여되었습니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "해당 모임이 존재하지 않습니다.")
+    })
+    @RequestMapping(value = "/{planId}/attendance", method = RequestMethod.POST)
+    public ResponseEntity<SuccessResponse<String>> joinPlan(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                            @PathVariable Long planId) {
+        return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(planService.joinPlan(userDetails.getUsername(), planId)));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
@@ -1,0 +1,34 @@
+package com.wemo.backend.domain.plan.entity;
+
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.entity.Timestamped;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_ATTENDANE")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Attendance extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attendance_id", nullable = false)
+    @Comment("참석 id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @Comment("유저 id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id")
+    @Comment("일정 id")
+    private Plan plan;
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
@@ -89,4 +89,14 @@ public class Plan extends Timestamped {
     @Comment("모임 id")
     private Meeting meeting;
 
+    public void open() {
+
+        this.opened = true;
+    }
+
+    public void close() {
+
+        this.fulled = true;
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/AttendanceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/AttendanceRepository.java
@@ -1,0 +1,15 @@
+package com.wemo.backend.domain.plan.repository;
+
+import com.wemo.backend.domain.plan.entity.Attendance;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    boolean existsByUserAndPlan(User user, Plan plan);
+
+    List<Attendance> findAllByPlan(Plan plan);
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.plan.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+
+public interface PlanReader {
+
+    Plan getPlan(Long planId);
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
@@ -1,0 +1,25 @@
+package com.wemo.backend.domain.plan.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.PlanRepository;
+import com.wemo.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_FOUND;
+
+@Component
+@RequiredArgsConstructor
+public class PlanReaderImpl implements PlanReader {
+
+    private final PlanRepository planRepository;
+
+    @Override
+    public Plan getPlan(Long planId) {
+
+        return planRepository.findById(planId).orElseThrow(
+                () -> new CustomException(ILLEGAL_PLAN_NOT_FOUND)
+        );
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -9,4 +9,6 @@ public interface PlanService {
 
     PlanCreateResponse createPlan(String email, PlanCreateRequest request, Long meetingId);
 
+    String joinPlan(String email, Long planId);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -41,6 +41,8 @@ public class PlanServiceImpl implements PlanService {
 
     private final PlanStore planStore;
 
+    private final PlanReader planReader;
+
     /**
      * 0. 일정 생성
      *
@@ -76,6 +78,9 @@ public class PlanServiceImpl implements PlanService {
 
         Plan plan = planStore.storePlan(request, district, user, meeting);
 
+        // 주최자는 일정에 자동으로 참여
+        planStore.joinPlan(user, plan);
+
         // 이미지 저장 (선택)
         if (!request.getFileUrl().isEmpty()) {
             Image image = imageStore.storeImage(user, plan.getId(), request.getFileUrl(), Image.EntityType.PLAN);
@@ -83,6 +88,24 @@ public class PlanServiceImpl implements PlanService {
         }
 
         return PlanCreateResponse.fromEntity(plan, meeting);
+    }
+
+    /**
+     * 일정 참여
+     *
+     * @param email 이메일
+     * @param planId 일정 id
+     * @return 성공 응답 메세지
+     */
+    @Override
+    public String joinPlan(String email, Long planId) {
+
+        User user = userReader.getUserByEmail(email);
+        Plan plan = planReader.getPlan(planId);
+
+        planStore.joinPlan(user, plan);
+
+        return "일정 참여 신청 완료되었습니다.";
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
@@ -10,4 +10,6 @@ public interface PlanStore {
 
     Plan storePlan(PlanCreateRequest request, District district, User user, Meeting meeting);
 
+    void joinPlan(User user, Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -2,21 +2,32 @@ package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.AttendanceRepository;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
 import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+import static com.wemo.backend.global.exception.ErrorCode.ALREADY_JOINED_PLAN;
+import static com.wemo.backend.global.exception.ErrorCode.PLAN_IS_FULLED;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class PlanStoreImpl implements PlanStore{
 
     private final PlanRepository planRepository;
+
+    private final AttendanceRepository attendanceRepository;
 
     @Override
     @Transactional
@@ -42,6 +53,26 @@ public class PlanStoreImpl implements PlanStore{
         planRepository.save(plan);
 
         return plan;
+    }
+
+    @Override
+    @Transactional
+    public void joinPlan(User user, Plan plan) {
+
+        // 이미 참여한 일정 예외 처리
+        boolean alreadyJoined = attendanceRepository.existsByUserAndPlan(user, plan);
+        if (alreadyJoined) throw new CustomException(ALREADY_JOINED_PLAN);
+
+        // 모집 정원 마감 예외 처리
+        List<Attendance> allByPlan = attendanceRepository.findAllByPlan(plan);
+        if (allByPlan.size() >= plan.getCapacity()) throw new CustomException(PLAN_IS_FULLED);
+
+        Attendance attendance = Attendance.builder()
+                .user(user)
+                .plan(plan)
+                .build();
+
+        attendanceRepository.save(attendance);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -73,6 +73,19 @@ public class PlanStoreImpl implements PlanStore{
                 .build();
 
         attendanceRepository.save(attendance);
+
+        // 인원 수 변경에 따른 일정 상태값 변경
+        updatePlanStatus(plan, allByPlan.size() + 1); // 기존 참여 인원에 새 참여자를 추가
+    }
+
+    @Transactional
+    private void updatePlanStatus(Plan plan, int participants) {
+        // 최소 인원 충족 시 개설 확정
+        if (participants >= 5) plan.open();
+
+        // 정원 마감 시 개설 마감
+        if (participants >= plan.getCapacity()) plan.close();
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -19,11 +19,14 @@ public enum ErrorCode {
 
     // meeting
     ILLEGAL_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
-    ALREADY_MEETING_JOINED(HttpStatus.BAD_REQUEST, "이미 가입된 모임입니다."),
+    ALREADY_JOINED_MEETING(HttpStatus.BAD_REQUEST, "이미 가입된 모임입니다."),
 
     // plan
     ILLEGAL_PLAN_NOT_GRANTED(HttpStatus.BAD_REQUEST, "모임장만 일정을 생성할 수 있습니다."),
-    ILLEGAL_ADDRESS_NOT_VALID(HttpStatus.BAD_REQUEST, "주소 값이 유효하지 않습니다.");
+    ILLEGAL_ADDRESS_NOT_VALID(HttpStatus.BAD_REQUEST, "주소 값이 유효하지 않습니다."),
+    ILLEGAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
+    ALREADY_JOINED_PLAN(HttpStatus.BAD_REQUEST, "이미 참여한 일정입니다."),
+    PLAN_IS_FULLED(HttpStatus.BAD_REQUEST, "모집 정원이 마감된 일정입니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 참여 기능 구현하였습니다.
- 일정 생성 시 주최자는 자동으로 참여되도록 수정하였습니다.
- 기존에 참여된 일정인 경우 중복 참여가 불가능하도록 설정하였고 만약 이 경우 예외가 반환됩니다.
- 참여 인원에 따른 일정 상태값을 변경합니다.
   - 최소 인원 충족 시 `개설 확정`, 모집 정원 마감 시 `개설 마감`
- 모집 정원이 다 찬 경우 추가 참여가 불가능하며 이에 맞는 예외가 반환됩니다.

<br/>

## 🌱 반영 브랜치
- feat/plan-join-15 -> dev
- close #15 

<br>