### PR TITLE
[Feat] 후기 생성 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -10,7 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_REFRESH_TOKEN_NOT_VALID;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
@@ -6,7 +6,7 @@ import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_NOT_FOUND;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
@@ -1,9 +1,12 @@
 package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
 
 public interface PlanReader {
 
     Plan getPlan(Long planId);
+
+    void validateAttendance(User user, Plan plan);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
@@ -1,12 +1,14 @@
 package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.AttendanceRepository;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
+import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_FOUND;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor
@@ -14,12 +16,23 @@ public class PlanReaderImpl implements PlanReader {
 
     private final PlanRepository planRepository;
 
+    private final AttendanceRepository attendanceRepository;
+
     @Override
     public Plan getPlan(Long planId) {
 
         return planRepository.findById(planId).orElseThrow(
                 () -> new CustomException(ILLEGAL_PLAN_NOT_FOUND)
         );
+    }
+
+    @Override
+    public void validateAttendance(User user, Plan plan) {
+
+        boolean exists = attendanceRepository.existsByUserAndPlan(user, plan);
+
+        if (!exists) throw new CustomException(PLAN_ATTENDANCE_NOT_FOUND);
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_GRANTED;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -17,8 +17,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.wemo.backend.global.exception.ErrorCode.ALREADY_JOINED_PLAN;
-import static com.wemo.backend.global.exception.ErrorCode.PLAN_IS_FULLED;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Slf4j
 @Component

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_ADDRESS_NOT_VALID;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Service
 public class RegionServiceImpl {

--- a/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
@@ -1,4 +1,40 @@
 package com.wemo.backend.domain.review.controller;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
+import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import com.wemo.backend.domain.review.service.ReviewService;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "Reviews")
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
 public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @Operation(summary = "후기 생성", description = "후기를 생성합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "후기가 등록되었습니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일정입니다.")
+    })
+    @RequestMapping(value = "/{planId}", method = RequestMethod.POST)
+    public ResponseEntity<SuccessResponse<ReviewCreateResponse>> createReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                              @PathVariable Long planId,
+                                                                              @Valid @RequestBody ReviewCreateRequest request) {
+        return ResponseEntity.status(201).body(SuccessResponse.successWithData(reviewService.createReview(userDetails.getUsername(), planId, request)));
+    }
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewCreateRequest.java
@@ -1,4 +1,24 @@
 package com.wemo.backend.domain.review.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public class ReviewCreateRequest {
+
+    @Max(5)
+    @NotNull(message = "평점은 0 ~ 5 사이의 정수 형태만 입력 가능합니다.")
+    private int score;
+
+    @NotBlank(message = "후기 내용은 필수 입력 값입니다.")
+    @Size(min = 5, max = 500, message = "후기는 최소 5자, 최대 500자로 입력 가능합니다.")
+    private String comment;
+
+    private String fileUrl;
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewCreateResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewCreateResponse.java
@@ -1,0 +1,41 @@
+package com.wemo.backend.domain.review.dto;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.entity.Review;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewCreateResponse {
+
+    private Long planId;
+
+    private int score;
+
+    private String comment;
+
+    private String reviewImagePath;
+
+    // 이미지가 있는 경우
+    public static ReviewCreateResponse fromEntityWithImage(Plan plan, Review review, Image image) {
+        return ReviewCreateResponse.builder()
+                .planId(plan.getId())
+                .score(review.getScore())
+                .comment(review.getComment())
+                .reviewImagePath(image.getFileUrl())
+                .build();
+    }
+
+
+    // 이미지가 없는 경우
+    public static ReviewCreateResponse fromEntity(Plan plan, Review review) {
+        return ReviewCreateResponse.builder()
+                .planId(plan.getId())
+                .score(review.getScore())
+                .comment(review.getComment())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/wemo/backend/domain/review/entity/Review.java
@@ -1,4 +1,51 @@
 package com.wemo.backend.domain.review.entity;
 
-public class Review {
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.entity.Timestamped;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Comment;
+
+@Entity
+@Table(name = "TB_REVIEW")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Review extends Timestamped {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "review_id", nullable = false)
+    @Comment("후기 id")
+    private Long id;
+
+    @Column(name = "score", nullable = false)
+    @Min(0)
+    @Max(5)
+    @Comment("후기 평점")
+    private int score;
+
+    @Column(name = "comment", nullable = false)
+    @Size(min = 5, max = 500)
+    @Comment("후기 내용")
+    private String comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id",nullable = false)
+    @Comment("유저 id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "plan_id", nullable = false)
+    @Comment("일정 id")
+    private Plan plan;
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -1,4 +1,12 @@
 package com.wemo.backend.domain.review.repository;
 
-public interface ReviewRepository {
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    boolean existsByUserAndPlan(User user, Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
@@ -1,4 +1,12 @@
 package com.wemo.backend.domain.review.service;
 
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
+import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import org.springframework.stereotype.Service;
+
+@Service
 public interface ReviewService {
+
+    ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request);
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -1,4 +1,79 @@
 package com.wemo.backend.domain.review.service;
 
-public class ReviewServiceImpl {
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.service.ImageStore;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
+import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.repository.ReviewRepository;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.domain.user.service.UserReader;
+import com.wemo.backend.global.exception.CustomException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+import static com.wemo.backend.global.exception.ErrorCode.*;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewServiceImpl implements ReviewService {
+
+    private final UserReader userReader;
+
+    private final PlanReader planReader;
+
+    private final ReviewRepository reviewRepository;
+
+    private final ReviewStore reviewStore;
+
+    private final ImageStore imageStore;
+
+    /**
+     * 후기 등록
+     *
+     * @param email 이메일
+     * @param planId 일정 id
+     * @param request 후기 생성 데이터 (평점, 내용, 이미지)
+     * @return 생성된 후기 정보
+     */
+    @Override
+    @Transactional
+    public ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request) {
+
+        // 유저 유효성 검사
+        User user = userReader.getUserByEmail(email);
+        // 일정 유효성 검사
+        Plan plan = planReader.getPlan(planId);
+
+        // 기존 후기 작성 여부 확인
+        boolean hasExistingReview = reviewRepository.existsByUserAndPlan(user, plan);
+        if (hasExistingReview) {
+            throw new CustomException(REVIEW_ALREADY_EXISTS);
+        }
+
+        // 참여 내역 검사
+        planReader.validateAttendance(user, plan);
+
+        // 일정이 완료되었는지 확인
+        if (plan.getDateTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(REVIEW_CREATION_BEFORE_PLAN_END);
+        }
+
+        // 후기 저장
+        Review review = reviewStore.storeReview(request, user, plan);
+
+        // 이미지 저장 (선택)
+        if (!request.getFileUrl().isEmpty()) {
+            Image image = imageStore.storeImage(user, review.getId(), request.getFileUrl(), Image.EntityType.REVIEW);
+            return ReviewCreateResponse.fromEntityWithImage(plan, review, image);
+        }
+        return ReviewCreateResponse.fromEntity(plan, review);
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewStore.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewStore.java
@@ -1,0 +1,12 @@
+package com.wemo.backend.domain.review.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.user.entity.User;
+
+public interface ReviewStore {
+
+    Review storeReview(ReviewCreateRequest request, User user, Plan plan);
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewStoreImpl.java
@@ -1,0 +1,34 @@
+package com.wemo.backend.domain.review.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.repository.ReviewRepository;
+import com.wemo.backend.domain.user.entity.User;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReviewStoreImpl implements ReviewStore {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    @Transactional
+    public Review storeReview(ReviewCreateRequest request, User user, Plan plan) {
+
+        Review review = Review.builder()
+                .score(request.getScore())
+                .comment(request.getComment())
+                .user(user)
+                .plan(plan)
+                .build();
+
+        reviewRepository.save(review);
+
+        return review;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -26,7 +26,13 @@ public enum ErrorCode {
     ILLEGAL_ADDRESS_NOT_VALID(HttpStatus.BAD_REQUEST, "주소 값이 유효하지 않습니다."),
     ILLEGAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
     ALREADY_JOINED_PLAN(HttpStatus.BAD_REQUEST, "이미 참여한 일정입니다."),
-    PLAN_IS_FULLED(HttpStatus.BAD_REQUEST, "모집 정원이 마감된 일정입니다.");
+    PLAN_IS_FULLED(HttpStatus.BAD_REQUEST, "모집 정원이 마감된 일정입니다."),
+    PLAN_ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 참여 기록이 없습니다."),
+
+    // review
+    REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST ,"이미 후기를 등록한 일정입니다."),
+    REVIEW_CREATION_BEFORE_PLAN_END(HttpStatus.BAD_REQUEST,"일정이 완료되지 않아 후기를 작성할 수 없습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 후기 생성 기능 구현하였습니다.
- 유저는 후기를 등록하고자 하는 일정에 참여한 내역이 있고, 해당 일정의 모임 날짜가 요청 시점보다 지난 경우에 등록 가능하도록 하였습니다.
- 유저가 해당 일정에 대해 이미 등록한 후기가 있다면 예외를 반환하도록 하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/review-create-14 -> dev
- close #14 

<br/>
