### PR TITLE
[Feat] 모임 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -132,7 +132,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/api/auths/signup") ||
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
-                requestURI.startsWith("/v3/api-docs");
+                requestURI.startsWith("/v3/api-docs") ||
+                requestURI.startsWith("/api/meetings");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
@@ -4,4 +4,7 @@ import com.wemo.backend.domain.image.entity.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
+
+    Image findByEntityIdAndEntityType(Long entityId, Image.EntityType entityType);
+
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.image.service;
+
+import com.wemo.backend.domain.image.entity.Image;
+
+public interface ImageReader {
+
+    Image getImage(Long entityId, Image.EntityType entityType);
+
+}

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
@@ -1,0 +1,20 @@
+package com.wemo.backend.domain.image.service;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.repository.ImageRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ImageReaderImpl implements ImageReader {
+
+    private final ImageRepository imageRepository;
+
+    @Override
+    public Image getImage(Long entityId, Image.EntityType entityType) {
+
+        return imageRepository.findByEntityIdAndEntityType(entityId, entityType);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.meeting.controller;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
 import com.wemo.backend.domain.meeting.service.MeetingService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -46,6 +47,17 @@ public class MeetingController {
     public ResponseEntity<SuccessResponse<String>> joinMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                @PathVariable Long meetingId) {
         return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(meetingService.joinMeeting(userDetails.getUsername(), meetingId)));
+    }
+
+    @Operation(summary = "모임 상세 조회", description = "모임 상세 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 모임에 대한 상세 정보입니다.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "해당 모임이 존재하지 않습니다.")
+    })
+    @RequestMapping(value = "/{meetingId}", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingDetailResponse>> getMeetingDetail(@PathVariable Long meetingId) {
+        return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getMeetingDetail(meetingId)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
@@ -1,0 +1,70 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.dto.PlanListInfo;
+import com.wemo.backend.domain.review.dto.ReviewListInfo;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class MeetingDetailResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String meetingImagePath;
+
+    private int memberCount;
+
+    private String description;
+
+    private String category;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private List<UserListInfo> memberList;
+
+    private int planCounts;
+
+    private List<PlanListInfo> planList;
+
+    private int reviewCounts;
+
+    private List<ReviewListInfo> reviewList;
+
+    public static MeetingDetailResponse fromEntity(Meeting meeting, Image meetingImage, int memberCount, List<UserListInfo> userListInfoList, int planCounts, List<PlanListInfo> planListInfoList, int reviewCounts, List<ReviewListInfo> reviewListInfoList) {
+
+        return MeetingDetailResponse.builder()
+                .meetingId(meeting.getId())
+                .meetingName(meeting.getMeetingName())
+                .meetingImagePath(meetingImage.getFileUrl())
+                .memberCount(memberCount)
+                .description(meeting.getDescription())
+                .category(meeting.getCategory().getCategoryName())
+                .nickname(meeting.getUser().getNickname())
+                .profileImagePath(meeting.getUser().getProfileImagePath())
+                .createdAt(meeting.getCreatedAt())
+                .updatedAt(meeting.getUpdatedAt())
+                .memberList(userListInfoList)
+                .planCounts(planCounts)
+                .planList(planListInfoList)
+                .reviewCounts(reviewCounts)
+                .reviewList(reviewListInfoList)
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/entity/MeetingMember.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/entity/MeetingMember.java
@@ -5,11 +5,13 @@ import com.wemo.backend.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(name = "TB_MEETING_MEMBER")
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingMemberRepository.java
@@ -5,8 +5,12 @@ import com.wemo.backend.domain.meeting.entity.MeetingMember;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Long> {
 
     boolean existsByUserAndMeeting(User user, Meeting meeting);
+
+    List<MeetingMember> findAllByMeeting(Meeting meeting);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
@@ -1,9 +1,14 @@
 package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.entity.MeetingMember;
+
+import java.util.List;
 
 public interface MeetingReader {
 
     Meeting getMeeting(Long meetingId);
+
+    List<MeetingMember> getMemberByMeeting(Meeting meeting);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
@@ -1,10 +1,14 @@
 package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.entity.MeetingMember;
+import com.wemo.backend.domain.meeting.repository.MeetingMemberRepository;
 import com.wemo.backend.domain.meeting.repository.MeetingRepository;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.wemo.backend.global.exception.ErrorCode.*;
 
@@ -14,9 +18,19 @@ public class MeetingReaderImpl implements MeetingReader {
 
     private final MeetingRepository meetingRepository;
 
+    private final MeetingMemberRepository meetingMemberRepository;
+
     public Meeting getMeeting(Long meetingId) {
         return meetingRepository.findById(meetingId).orElseThrow(
                 () -> new CustomException(ILLEGAL_MEETING_NOT_FOUND)
         );
     }
+
+    @Override
+    public List<MeetingMember> getMemberByMeeting(Meeting meeting) {
+
+        return meetingMemberRepository.findAllByMeeting(meeting);
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -9,5 +10,7 @@ public interface MeetingService {
     void createMeeting(String email, MeetingCreateRequest request);
 
     String joinMeeting(String email, Long meetingId);
+
+    MeetingDetailResponse getMeetingDetail(Long meetingId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -1,14 +1,28 @@
 package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
+import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.dto.PlanListInfo;
+import com.wemo.backend.domain.plan.entity.Attendance;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
+import com.wemo.backend.domain.review.dto.ReviewListInfo;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.service.ReviewReader;
+import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,6 +32,9 @@ public class MeetingServiceImpl implements MeetingService {
     private final MeetingStore meetingStore;
     private final ImageStore imageStore;
     private final MeetingReader meetingReader;
+    private final PlanReader planReader;
+    private final ReviewReader reviewReader;
+    private final ImageReader imageReader;
 
     /**
      * 0. 모임 생성
@@ -60,6 +77,75 @@ public class MeetingServiceImpl implements MeetingService {
         meetingStore.joinMeeting(user, meeting);
 
         return "모임 가입 성공";
+    }
+
+    /**
+     * 모임 상세 조회
+     *
+     * @param meetingId 모임 id
+     * @return 모임에 관련된 모든 정보 반환 (모임 정보, 멤버 리스트, 일정 리스트, 후기 리스트)
+     */
+    @Override
+    public MeetingDetailResponse getMeetingDetail(Long meetingId) {
+
+        // 모임 유효성 검사
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+
+        // 모임 이미지 가져오기
+        Image meetingImage = imageReader.getImage(meeting.getId(), Image.EntityType.MEETING);
+
+        // 모임 멤버 정보 가져오기
+        List<UserListInfo> userListInfoList = getUserListInfo(meeting);
+
+        // 일정 정보 가져오기
+        List<PlanListInfo> planListInfoList = getPlanListInfo(meeting);
+
+        // 리뷰 정보 가져오기
+        List<ReviewListInfo> reviewListInfoList = getReviewListInfo(planListInfoList);
+
+        return MeetingDetailResponse.fromEntity(
+                meeting,
+                meetingImage,
+                userListInfoList.size(),
+                userListInfoList,
+                planListInfoList.size(),
+                planListInfoList,
+                reviewListInfoList.size(),
+                reviewListInfoList
+        );
+    }
+
+    private List<UserListInfo> getUserListInfo(Meeting meeting) {
+        return meetingReader.getMemberByMeeting(meeting).stream()
+                .map(UserListInfo::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    private List<PlanListInfo> getPlanListInfo(Meeting meeting) {
+        List<Plan> planList = planReader.getPlanByMeeting(meeting);
+
+        return planList.stream().map(plan -> {
+            List<Attendance> attendanceList = planReader.getAttendanceList(plan);
+            Image planImage = imageReader.getImage(plan.getId(), Image.EntityType.PLAN);
+
+            return PlanListInfo.fromEntity(plan, attendanceList.size(), planImage);
+        }).collect(Collectors.toList());
+    }
+
+    private List<ReviewListInfo> getReviewListInfo(List<PlanListInfo> planListInfoList) {
+        List<ReviewListInfo> reviewListInfoList = new ArrayList<>();
+
+        for (PlanListInfo planListInfo : planListInfoList) {
+            Plan plan = planReader.getPlan(planListInfo.getPlanId());
+            List<Review> reviews = reviewReader.getReviewByPlan(plan);
+
+            reviews.forEach(review -> {
+                ReviewListInfo reviewListInfo = ReviewListInfo.fromEntity(review);
+                reviewListInfoList.add(reviewListInfo);
+            });
+        }
+
+        return reviewListInfoList;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanListInfo.java
@@ -1,0 +1,44 @@
+package com.wemo.backend.domain.plan.dto;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.plan.entity.Plan;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PlanListInfo {
+
+    private Long planId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private int participants;
+
+    private int capacity;
+
+    private String planImagePath;
+
+    private boolean isOpened;
+
+    private boolean isFulled;
+
+    public static PlanListInfo fromEntity(Plan plan, int participants, Image image) {
+
+        return PlanListInfo.builder()
+                .planId(plan.getId())
+                .planName(plan.getPlanName())
+                .dateTime(plan.getDateTime())
+                .participants(participants)
+                .capacity(plan.getCapacity())
+                .planImagePath(image.getFileUrl())
+                .isOpened(plan.isOpened())
+                .isFulled(plan.isFulled())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -1,7 +1,12 @@
 package com.wemo.backend.domain.plan.repository;
 
+import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface PlanRepository extends JpaRepository<Plan, Long> {
+
+    List<Plan> findAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
@@ -1,12 +1,20 @@
 package com.wemo.backend.domain.plan.service;
 
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
+
+import java.util.List;
 
 public interface PlanReader {
 
     Plan getPlan(Long planId);
 
     void validateAttendance(User user, Plan plan);
+
+    List<Plan> getPlanByMeeting(Meeting meeting);
+
+    List<Attendance> getAttendanceList(Plan plan);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
@@ -1,5 +1,7 @@
 package com.wemo.backend.domain.plan.service;
 
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.AttendanceRepository;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
@@ -7,6 +9,8 @@ import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.wemo.backend.global.exception.ErrorCode.*;
 
@@ -33,6 +37,18 @@ public class PlanReaderImpl implements PlanReader {
 
         if (!exists) throw new CustomException(PLAN_ATTENDANCE_NOT_FOUND);
 
+    }
+
+    @Override
+    public List<Plan> getPlanByMeeting(Meeting meeting) {
+
+        return planRepository.findAllByMeeting(meeting);
+    }
+
+    @Override
+    public List<Attendance> getAttendanceList(Plan plan) {
+
+        return attendanceRepository.findAllByPlan(plan);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewListInfo.java
@@ -1,0 +1,41 @@
+package com.wemo.backend.domain.review.dto;
+
+import com.wemo.backend.domain.review.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ReviewListInfo {
+
+    private Long reviewId;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private int score;
+
+    private String comment;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    public static ReviewListInfo fromEntity(Review review) {
+
+        return ReviewListInfo.builder()
+                .reviewId(review.getId())
+                .nickname(review.getUser().getNickname())
+                .profileImagePath(review.getUser().getProfileImagePath())
+                .score(review.getScore())
+                .comment(review.getComment())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -5,8 +5,12 @@ import com.wemo.backend.domain.review.entity.Review;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     boolean existsByUserAndPlan(User user, Plan plan);
+
+    List<Review> findAllByPlan(Plan plan);
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
@@ -1,0 +1,12 @@
+package com.wemo.backend.domain.review.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.entity.Review;
+
+import java.util.List;
+
+public interface ReviewReader {
+
+    List<Review> getReviewByPlan(Plan plan);
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
@@ -1,0 +1,23 @@
+package com.wemo.backend.domain.review.service;
+
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.repository.ReviewRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReviewReaderImpl implements ReviewReader {
+
+    private final ReviewRepository reviewRepository;
+
+    @Override
+    public List<Review> getReviewByPlan(Plan plan) {
+
+        return reviewRepository.findAllByPlan(plan);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
@@ -1,0 +1,28 @@
+package com.wemo.backend.domain.user.dto;
+
+import com.wemo.backend.domain.meeting.entity.MeetingMember;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class UserListInfo {
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private LocalDateTime createdAt;
+
+    public static UserListInfo fromEntity(MeetingMember meetingMember) {
+
+        return UserListInfo.builder()
+                .nickname(meetingMember.getUser().getNickname())
+                .profileImagePath(meetingMember.getUser().getProfileImagePath())
+                .createdAt(meetingMember.getCreatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -85,8 +86,10 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**"
                                 ).permitAll()
+                                // 비회원 허용 경로
+                                .requestMatchers(HttpMethod.GET, "/api/meetings/**").permitAll()
 
-                        .anyRequest().authenticated()
+                                .anyRequest().authenticated()
 
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, tokenBlacklistService), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 상세 조회 기능 구현하였습니다.
- API 명세에 맞게 모임에 대한 모든 정보를 반환할 수 있도록 하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/meeting-detail-10 -> dev
- close #10 

<br/>

## 🔥 트러블 슈팅 (선택)
- 이미지에 대한 데이터 관리가 확정되지 않은 부분이 있어 임의로 하나씩만 등록했다는 가정 하에 진행하였습니다. 추후 배열 형태의 이미지 등록으로 수정될 경우 대표 이미지를 판단하여 반환하는 데이터에 조건이 추가될 예정입니다.
