### PR TITLE
[Feat] 일정 목록 조회 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,8 +58,38 @@ dependencies {
 	// Redis 관련 의존성
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// queryDsl 관련 의존성
+	implementation "com.querydsl:querydsl-jpa:5.0.0:jakarta"
+	implementation "com.querydsl:querydsl-core:5.0.0"
+	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api:2.1.0"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api:3.1.0"
+
+}
+
+tasks.processResources {
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+}
+
+// 경로설정
+def querydslDir = "$buildDir/generated/querydsl"
+
+sourceSets {
+	main {
+		java {
+			srcDirs += querydslDir
+		}
+	}
+}
+
+tasks.withType(JavaCompile) {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
 }
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jar {
+	enabled = false
 }

--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -133,7 +133,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
                 requestURI.startsWith("/v3/api-docs") ||
-                requestURI.startsWith("/api/meetings");
+                requestURI.startsWith("/api/meetings") ||
+                requestURI.startsWith("/api/plans");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/UserDetailsImpl.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserDetailsImpl.java
@@ -14,6 +14,11 @@ public record UserDetailsImpl(User user) implements UserDetails {
         return null;
     }
 
+    public boolean isGuest() {
+
+        return this.getUsername() == null || this.getUsername().isEmpty();
+    }
+
     @Override
     public String getPassword() {
 

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.plan.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.service.PlanService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -26,9 +27,9 @@ public class PlanController {
 
     @Operation(summary = "일정 생성", description = "일정을 생성합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "일정이 생성되었습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+            @ApiResponse(responseCode = "201", description = "일정이 생성되었습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/{meetingId}", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<PlanCreateResponse>> createPlan(@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -40,14 +41,34 @@ public class PlanController {
 
     @Operation(summary = "일정 참여", description = "일정에 참여합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "일정에 참여되었습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "404", description = "해당 모임이 존재하지 않습니다.")
+            @ApiResponse(responseCode = "201", description = "일정에 참여되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일정입니다.",
+                    content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/{planId}/attendance", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> joinPlan(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                             @PathVariable Long planId) {
         return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(planService.joinPlan(userDetails.getUsername(), planId)));
+    }
+
+    @Operation(summary = "일정 목록 조회", description = "회원 또는 비회원이 요청하는 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 일정 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<PlanCursorPagingResponse>> getGatherings(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                   @RequestParam(required = false) Long cursor, // 커서 파라미터 추가
+                                                                                   @RequestParam int size,
+                                                                                   @RequestParam(required = false) String query,
+                                                                                   @RequestParam(required = false) String province,
+                                                                                   @RequestParam(required = false) String district,
+                                                                                   @RequestParam(required = false) String startDate,
+                                                                                   @RequestParam(required = false) String endDate,
+                                                                                   @RequestParam(required = false) Long categoryId,
+                                                                                   @RequestParam(required = false) String sort) {
+
+        PlanCursorPagingResponse response = planService.getPlanList(userDetails, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanCursorPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanCursorPagingResponse.java
@@ -1,0 +1,27 @@
+package com.wemo.backend.domain.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PlanCursorPagingResponse {
+
+    private int planCount;
+
+    private List<PlanListResponse> planList;
+
+    private Long nextCursor;
+
+    public PlanCursorPagingResponse(List<PlanListResponse> planListResponses, int planCount) {
+
+        this.planCount = planCount;
+        this.planList = planListResponses;
+        this.nextCursor = planListResponses.isEmpty() ? null : planListResponses.get(planListResponses.size() - 1).getPlanId();
+
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
@@ -1,0 +1,56 @@
+package com.wemo.backend.domain.plan.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PlanListResponse {
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private Long planId;
+
+    private String planName;
+
+    private String category;
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String address;
+
+    private String province;
+
+    private String district;
+
+    private String planImagePath;
+
+    private LocalDateTime dateTime;
+
+    private LocalDateTime registrationEnd;
+
+    private int capacity;
+
+    private Long participants;
+
+    private Long likeCount;
+
+    private int viewCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private boolean isOpened;
+
+    private boolean isFulled;
+
+    private boolean isLiked;
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
@@ -89,6 +89,10 @@ public class Plan extends Timestamped {
     @Comment("모임 id")
     private Meeting meeting;
 
+    @Column(name = "view_count")
+    @Comment("조회수")
+    private int viewCount;
+
     public void open() {
 
         this.opened = true;

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -2,11 +2,12 @@ package com.wemo.backend.domain.plan.repository;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.querydsl.PlanCursorQueryDsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PlanRepository extends JpaRepository<Plan, Long> {
+public interface PlanRepository extends JpaRepository<Plan, Long>, PlanCursorQueryDsl {
 
     List<Plan> findAllByMeeting(Meeting meeting);
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDsl.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.plan.repository.querydsl;
+
+import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
+
+public interface PlanCursorQueryDsl {
+
+    PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+    PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -1,0 +1,217 @@
+package com.wemo.backend.domain.plan.repository.querydsl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.ConstructorExpression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
+import com.wemo.backend.domain.plan.dto.PlanListResponse;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.like.entity.QLike.like;
+import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
+import static com.wemo.backend.domain.plan.entity.QAttendance.attendance;
+import static com.wemo.backend.domain.plan.entity.QPlan.plan;
+import static com.wemo.backend.domain.region.entity.QDistrict.district;
+import static com.wemo.backend.domain.region.entity.QProvince.province;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+@Slf4j
+public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
+
+    private static final String DEFAULT_SORT_FIELD = "createdAt";
+
+    private final JPAQueryFactory queryFactory;
+
+    public PlanCursorQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+
+    @Override
+    public PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        return getPlanList(email, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+    }
+
+    @Override
+    public PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        return getPlanList(null, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+    }
+
+
+    private PlanCursorPagingResponse getPlanList(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        updateIsClosedStatus();
+
+        log.info("{} 모임 목록 조회 요청", (email != null) ? email : "비회원");
+
+        String sortField = (sort == null) ? DEFAULT_SORT_FIELD : sort;
+
+        // 커서 조건을 제외한 기본 조건 빌더
+        BooleanBuilder baseConditions = new BooleanBuilder()
+                .and(buildFilterConditions(query, province, district, startDate, endDate, categoryId));
+
+        // 1. 목록 조회 쿼리 (커서 조건 포함)
+        BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
+        if (cursor != null) {
+            listConditions.and(plan.id.lt(cursor));
+        }
+
+        List<PlanListResponse> planListResponses = queryFactory
+                .select(buildGatheringListProjection(email))
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .where(listConditions)
+                .orderBy(sortField.equals("closeDate") ? plan.registrationEnd.asc() : plan.createdAt.desc())
+                .limit(size)
+                .fetch();
+
+        // 2. 전체 개수 조회 쿼리 (커서 조건 제외)
+        long planCount = Optional.ofNullable(
+                queryFactory
+                        .select(plan.count())
+                        .from(plan)
+                        .where(baseConditions)
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PlanCursorPagingResponse(planListResponses, (int) planCount);
+    }
+
+    private ConstructorExpression<PlanListResponse> buildGatheringListProjection(String email) {
+
+        return Projections.constructor(
+                PlanListResponse.class,
+                user.nickname.as("nickname"),
+                user.profileImagePath.as("profileImage"),
+                plan.id.as("planId"),
+                plan.planName,
+                Expressions.as(
+                        queryFactory.select(meeting.category.categoryName)
+                                .from(meeting)
+                                .where(meeting.id.eq(plan.meeting.id)),
+                        "category"
+                ),
+                Expressions.as(
+                        queryFactory.select(meeting.id)
+                                .from(meeting)
+                                .where(meeting.id.eq(plan.meeting.id)),
+                        "meetingId"
+                ),
+                Expressions.as(
+                        queryFactory.select(meeting.meetingName)
+                                .from(meeting)
+                                .where(meeting.id.eq(plan.meeting.id)),
+                        "meetingName"
+                ),
+                plan.address,
+                Expressions.as(
+                        queryFactory.select(province.provinceName)
+                                .from(province)
+                                .where(plan.district.province.id.eq(province.id)),
+                        "province"
+                ),
+                Expressions.as(
+                        queryFactory.select(district.districtName)
+                                .from(district)
+                                .where(plan.district.id.eq(district.id)),
+                        "district"
+                ),
+                Expressions.as(
+                        queryFactory.select(image.fileUrl)
+                                .from(image)
+                                .where(image.entityId.eq(plan.id),
+                                        image.entityType.eq(Image.EntityType.PLAN)),
+                        "planImagePath"
+                ),
+                plan.dateTime,
+                plan.registrationEnd,
+                plan.capacity,
+                Expressions.as(
+                        queryFactory.select(attendance.count())
+                                .from(attendance)
+                                .where(attendance.plan.id.eq(plan.id)
+                                        .and(attendance.deletedAt.isNull())),
+                        "participants"
+                ),
+                Expressions.as(
+                        queryFactory.select(like.count())
+                                .from(like)
+                                .where(like.plan.id.eq(plan.id)),
+                        "likeCount"
+                ),
+                plan.viewCount,
+                plan.createdAt,
+                plan.updatedAt,
+                plan.opened,
+                plan.fulled,
+                Expressions.as(
+                        queryFactory.select(like.count())
+                                .from(like)
+                                .where(
+                                        like.plan.id.eq(plan.id)
+                                                .and(
+                                                        email != null
+                                                                ? like.user.email.eq(email)
+                                                                : like.user.email.isNull()
+                                                )
+                                ).gt(0L),
+                        "isLiked")
+        );
+    }
+
+    private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
+
+        BooleanExpression condition = plan.canceled.eq(false);
+
+        if (query != null && !query.isEmpty()) {
+            condition = condition.and(plan.planName.contains(query));
+        }
+
+        if (province != null && !province.isEmpty()) {
+            condition = condition.and(plan.district.province.provinceName.eq(province));
+        }
+
+        if (district != null && !district.isEmpty()) {
+            condition = condition.and(plan.district.districtName.eq(district));
+        }
+
+        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            condition = condition.and(plan.dateTime.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (categoryId != null) {
+            condition = condition.and(plan.meeting.category.id.eq(categoryId));
+        }
+
+        return condition;
+    }
+
+    private void updateIsClosedStatus() {
+
+        long updatedCount = queryFactory.update(plan)
+                .set(plan.fulled, true)
+                .where(plan.registrationEnd.before(LocalDateTime.now())
+                        .and(plan.fulled.eq(false)))
+                .execute();
+
+        log.info("모임의 모집 마감 상태가 {} 번 업데이트되었습니다.", updatedCount);
+    }
+
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -1,7 +1,9 @@
 package com.wemo.backend.domain.plan.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -10,5 +12,7 @@ public interface PlanService {
     PlanCreateResponse createPlan(String email, PlanCreateRequest request, Long meetingId);
 
     String joinPlan(String email, Long planId);
+
+    PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -1,12 +1,15 @@
 package com.wemo.backend.domain.plan.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.service.MeetingReader;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
+import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.repository.PlanRepository;
 import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.domain.region.repository.DistrictRepository;
@@ -42,6 +45,8 @@ public class PlanServiceImpl implements PlanService {
     private final PlanStore planStore;
 
     private final PlanReader planReader;
+
+    private final PlanRepository planRepository;
 
     /**
      * 0. 일정 생성
@@ -98,6 +103,7 @@ public class PlanServiceImpl implements PlanService {
      * @return 성공 응답 메세지
      */
     @Override
+    @Transactional
     public String joinPlan(String email, Long planId) {
 
         User user = userReader.getUserByEmail(email);
@@ -106,6 +112,23 @@ public class PlanServiceImpl implements PlanService {
         planStore.joinPlan(user, plan);
 
         return "일정 참여 신청 완료되었습니다.";
+    }
+
+    @Override
+    @Transactional
+    public PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        PlanCursorPagingResponse response;
+
+        if (userDetails != null && !userDetails.isGuest()) {
+            // 회원인 경우
+            response = planRepository.getPlanListByUser(userDetails.getUsername(), cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        } else {
+            // 비회원인 경우
+            response = planRepository.getPlanListByGuest(cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        }
+
+        return response;
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -88,6 +88,7 @@ public class SecurityConfig {
                                 ).permitAll()
                                 // 비회원 허용 경로
                                 .requestMatchers(HttpMethod.GET, "/api/meetings/**").permitAll()
+                                .requestMatchers(HttpMethod.GET, "/api/plans/**").permitAll()
 
                                 .anyRequest().authenticated()
 

--- a/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
@@ -18,7 +18,8 @@ public class SwaggerConfig {
                 .info(apiInfo())
                 .addTagsItem(new Tag().name("Users").description("사용자 관련 API"))
                 .addTagsItem(new Tag().name("Meetings").description("모임 관련 API"))
-                .addTagsItem(new Tag().name("Plans").description("일정 관련 API"));
+                .addTagsItem(new Tag().name("Plans").description("일정 관련 API"))
+                .addTagsItem(new Tag().name("Reviews").description("후기 관련 API"));
 
     }
 


### PR DESCRIPTION

## 📌 작업 내용 (필수)
- 일정 목록 조회 기능 구현  
- QueryDSL을 활용한 필터링 및 검색 기능 추가 (성능 및 유지보수성 향상)  
- 회원/비회원 모두 사용 가능하도록 **filter 및 securityConfig** 허용 경로 설정  
- 조회 수 관리를 위해 일정 테이블에 **조회 수 컬럼 추가**  
  - 추후 Redis 등 **캐싱 시스템 도입 예정** (성능 최적화)  

<br/>

## 🌱 반영 브랜치
- `feat/plan-list-21` → `dev`  
- **close #21**  

<br/>

## 🔥 트러블 슈팅 (선택)
**🛑 문제:** QueryDSL 설정 적용 중 `build.gradle` 설정 문제로 컴파일 에러(Q-class 생성 실패) 발생  
**✅ 해결:** `annotationProcessor` 설정 수정 및 QueryDSL 관련 플러그인 의존성 추가
