### PR TITLE
[Feat] 일정 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -28,6 +28,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws IOException {
         try {
             String requestURI = request.getRequestURI();
+            String method = request.getMethod(); // HTTP 메서드 가져오기
+
             String accessToken = jwtTokenProvider.resolveToken(request);
             String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
 
@@ -38,6 +40,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             if (isExcludedPath(requestURI)) {
                 filterChain.doFilter(request, response); // 필터를 건너뜀
                 return;
+            }
+
+            if (requestURI.startsWith("/api/plans") && "GET".equalsIgnoreCase(method)) {
+                // 토큰이 없는 경우 비회원으로 처리
+                if (accessToken == null) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
             }
 
             // 로그아웃 요청 처리
@@ -127,14 +137,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private boolean isExcludedPath(String requestURI) {
+
         return requestURI.startsWith("/api/auths/check-email") ||
                 requestURI.startsWith("/api/auths/signin") ||
                 requestURI.startsWith("/api/auths/signup") ||
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
                 requestURI.startsWith("/v3/api-docs") ||
-                requestURI.startsWith("/api/meetings") ||
-                requestURI.startsWith("/api/plans");
+                requestURI.startsWith("/api/meetings");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
@@ -11,4 +11,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     Like findByUserAndPlan(User user, Plan plan);
 
+    int countByPlan(Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
@@ -1,0 +1,30 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MeetingInfoResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String description;
+
+    private String meetingImagePath;
+
+    public static MeetingInfoResponse fromEntity(Meeting meeting, String meetingImagePath) {
+
+        return MeetingInfoResponse.builder()
+                .meetingId(meeting.getId())
+                .meetingName(meeting.getMeetingName())
+                .description(meeting.getDescription())
+                .meetingImagePath(meetingImagePath)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
@@ -4,4 +4,5 @@ import com.wemo.backend.domain.meeting.entity.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -5,6 +5,7 @@ import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.service.PlanService;
+import com.wemo.backend.domain.review.dto.PlanDetailResponse;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -69,6 +70,20 @@ public class PlanController {
 
         PlanCursorPagingResponse response = planService.getPlanList(userDetails, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
+    }
+
+    @Operation(summary = "일정 상세 조회", description = "회원 또는 비회원이 요청한 일정의 상세 정보를 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 일정의 상세 내용이 반환되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일정입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{planId}", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<PlanDetailResponse>> getPlanDetail(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                             @PathVariable Long planId) {
+
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(planService.getPlanDetail(userDetails, planId)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanCursorPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanCursorPagingResponse.java
@@ -21,7 +21,6 @@ public class PlanCursorPagingResponse {
         this.planList = planListResponses;
         this.nextCursor = planListResponses.isEmpty() ? null : planListResponses.get(planListResponses.size() - 1).getPlanId();
 
-
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
@@ -5,11 +5,13 @@ import com.wemo.backend.global.entity.Timestamped;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.Comment;
 
 @Entity
 @Table(name = "TB_ATTENDANE")
+@Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
@@ -103,4 +103,10 @@ public class Plan extends Timestamped {
         this.fulled = true;
     }
 
+    public void updateViewCount() {
+
+        this.viewCount++;
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface PlanRepository extends JpaRepository<Plan, Long>, PlanCursorQueryDsl {
 
     List<Plan> findAllByMeeting(Meeting meeting);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -4,6 +4,7 @@ import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
+import com.wemo.backend.domain.review.dto.PlanDetailResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,5 +15,7 @@ public interface PlanService {
     String joinPlan(String email, Long planId);
 
     PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+    PlanDetailResponse getPlanDetail(UserDetailsImpl userDetails, Long planId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -2,12 +2,16 @@ package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
+import com.wemo.backend.domain.like.repository.LikeRepository;
+import com.wemo.backend.domain.meeting.dto.MeetingInfoResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.service.MeetingReader;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
 import com.wemo.backend.domain.region.entity.District;
@@ -15,6 +19,8 @@ import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.domain.region.repository.DistrictRepository;
 import com.wemo.backend.domain.region.repository.ProvinceRepository;
 import com.wemo.backend.domain.region.service.RegionServiceImpl;
+import com.wemo.backend.domain.review.dto.PlanDetailResponse;
+import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
 import com.wemo.backend.global.exception.CustomException;
@@ -23,9 +29,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
-import static com.wemo.backend.global.exception.ErrorCode.*;
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_GRANTED;
 
 @Slf4j
 @Service
@@ -47,6 +55,10 @@ public class PlanServiceImpl implements PlanService {
     private final PlanReader planReader;
 
     private final PlanRepository planRepository;
+
+    private final LikeRepository likeRepository;
+
+    private final ImageReader imageReader;
 
     /**
      * 0. 일정 생성
@@ -129,6 +141,65 @@ public class PlanServiceImpl implements PlanService {
         }
 
         return response;
+    }
+
+    @Override
+    @Transactional
+    public PlanDetailResponse getPlanDetail(UserDetailsImpl userDetails, Long planId) {
+
+        // 일정 유효성 검사
+        Plan plan = planReader.getPlan(planId);
+
+        // 일정 이미지 URL 조회
+        String planImageUrl = getImageUrl(planId, Image.EntityType.PLAN);
+
+        // 일정 참여자 및 좋아요 정보 조회
+        List<UserListInfo> userList = getUserListFromAttendance(plan);
+        int participants = userList.size();
+
+        int likeCount = likeRepository.countByPlan(plan);
+        boolean isLiked = isPlanLikedByUser(userDetails, plan);
+        log.info("일정에 대한 좋아요 여부 : {}", isLiked);
+
+        // 일정으로 모임 정보 생성
+        MeetingInfoResponse meetingInfoResponse = getMeetingInfoResponse(plan);
+
+        plan.updateViewCount();
+
+        // PlanDetailResponse 생성 및 반환
+        return PlanDetailResponse.fromEntity(plan, planImageUrl, plan.getMeeting(), participants, likeCount, userList, meetingInfoResponse, isLiked);
+    }
+
+    private String getImageUrl(Long entityId, Image.EntityType entityType) {
+
+        Image image = imageReader.getImage(entityId, entityType);
+        return image != null ? image.getFileUrl() : null;
+    }
+
+    private List<UserListInfo> getUserListFromAttendance(Plan plan) {
+
+        List<Attendance> attendanceList = planReader.getAttendanceList(plan);
+        return attendanceList.stream()
+                .map(UserListInfo::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    private boolean isPlanLikedByUser(UserDetailsImpl userDetails, Plan plan) {
+
+        if (userDetails == null || userDetails.isGuest()) {
+            return false;
+        }
+
+        User user = userReader.getUserByEmail(userDetails.getUsername());
+        log.info("일정 상세 조회 시 유저 존재 : {}", user.getEmail());
+        return likeRepository.existsByUserAndPlan(user, plan);
+    }
+
+    private MeetingInfoResponse getMeetingInfoResponse(Plan plan) {
+
+        Meeting meeting = plan.getMeeting();
+        String meetingImageUrl = getImageUrl(meeting.getId(), Image.EntityType.MEETING);
+        return MeetingInfoResponse.fromEntity(meeting, meetingImageUrl);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
@@ -38,4 +38,5 @@ public class ReviewController {
                                                                               @Valid @RequestBody ReviewCreateRequest request) {
         return ResponseEntity.status(201).body(SuccessResponse.successWithData(reviewService.createReview(userDetails.getUsername(), planId, request)));
     }
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/PlanDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/PlanDetailResponse.java
@@ -1,0 +1,96 @@
+package com.wemo.backend.domain.review.dto;
+
+import com.wemo.backend.domain.meeting.dto.MeetingInfoResponse;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+public class PlanDetailResponse {
+
+    private Long planId;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private String planName;
+
+    private String category;
+
+    private String address;
+
+    private double longitude;
+
+    private double latitude;
+
+    private String planImagePath;
+
+    private String content;
+
+    private LocalDateTime dateTime;
+
+    private LocalDateTime registrationEnd;
+
+    private int capacity;
+
+    private int participants;
+
+    private int likeCount;
+
+    private int viewCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private List<UserListInfo> userList;
+    
+    private MeetingInfoResponse meetingInfo;
+
+    private boolean isCanceled;
+
+    private boolean isLiked;
+
+    private boolean isOpened;
+
+    private boolean isFulled;
+
+    public static PlanDetailResponse fromEntity(Plan plan, String planImagePath, Meeting meeting, int participants, int likeCount, List<UserListInfo> userList, MeetingInfoResponse meetingInfoResponse, boolean isLiked) {
+
+        return PlanDetailResponse.builder()
+                .planId(plan.getId())
+                .nickname(plan.getUser().getNickname())
+                .profileImagePath(plan.getUser().getProfileImagePath())
+                .planName(plan.getPlanName())
+                .category(meeting.getCategory().getCategoryName())
+                .address(plan.getAddress())
+                .longitude(plan.getLongitude())
+                .latitude(plan.getLatitude())
+                .planImagePath(planImagePath)
+                .content(plan.getContent())
+                .dateTime(plan.getDateTime())
+                .registrationEnd(plan.getRegistrationEnd())
+                .capacity(plan.getCapacity())
+                .participants(participants)
+                .likeCount(likeCount)
+                .viewCount(plan.getViewCount())
+                .createdAt(plan.getCreatedAt())
+                .updatedAt(plan.getUpdatedAt())
+                .userList(userList)
+                .meetingInfo(meetingInfoResponse)
+                .isCanceled(plan.isCanceled())
+                .isLiked(isLiked)
+                .isOpened(plan.isOpened())
+                .isFulled(plan.isFulled())
+                .build();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.user.dto;
 
 import com.wemo.backend.domain.meeting.entity.MeetingMember;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -22,6 +23,15 @@ public class UserListInfo {
                 .nickname(meetingMember.getUser().getNickname())
                 .profileImagePath(meetingMember.getUser().getProfileImagePath())
                 .createdAt(meetingMember.getCreatedAt())
+                .build();
+    }
+
+    public static UserListInfo fromEntity(Attendance attendance) {
+
+        return UserListInfo.builder()
+                .nickname(attendance.getUser().getNickname())
+                .profileImagePath(attendance.getUser().getProfileImagePath())
+                .createdAt(attendance.getCreatedAt())
                 .build();
     }
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 상세 조회 기능 구현하였습니다.
- 회원/비회원 모두 하나의 API로 통신하기에 filter단에서 토큰 검증 유무에 따라 분기 처리하였습니다.
- 조회 시마다 조회 수가 증가하도록 구현하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/plan-detail-25 -> dev
- close #25 

<br/>

## 🔥 트러블 슈팅 (선택)
- 문제: 회원과 비회원 모두 하나의 API로 접근 가능하도록 작업 중, 필터 단에서 토큰 검증 로직이 적용되지 않아 좋아요 여부와 같은 인증 정보가 정상적으로 반환되지 않는 문제가 발생

   -> 해결: 필터 단 로직을 수정하여 해당 경로에 대한 GET 요청 시, 토큰의 유무에 따라 각각의 흐름으로 분기되도록 조건을 추가하여 문제를 해결