### PR TITLE
[Style] 일정 관련 응답 boolean 형태 컬럼명 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanListInfo.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.plan.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.plan.entity.Plan;
 import lombok.Builder;
@@ -23,10 +24,21 @@ public class PlanListInfo {
 
     private String planImagePath;
 
+    @JsonProperty("isOpened")
     private boolean isOpened;
 
+    @JsonProperty("isFulled")
     private boolean isFulled;
 
+    @JsonProperty("isOpened")
+    public boolean getIsOpened() {
+        return isOpened;
+    }
+
+    @JsonProperty("isFulled")
+    public boolean getIsFulled() {
+        return isFulled;
+    }
     public static PlanListInfo fromEntity(Plan plan, int participants, Image image) {
 
         return PlanListInfo.builder()

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.plan.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -46,11 +47,29 @@ public class PlanListResponse {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
-
+    
+    @JsonProperty("isOpened")
     private boolean isOpened;
 
+    @JsonProperty("isFulled")
     private boolean isFulled;
 
+    @JsonProperty("isLiked")
     private boolean isLiked;
+
+    @JsonProperty("isOpened")
+    public boolean getIsOpened() {
+        return isOpened;
+    }
+
+    @JsonProperty("isFulled")
+    public boolean getIsFulled() {
+        return isFulled;
+    }
+
+    @JsonProperty("isLiked")
+    public boolean getIsLiked() {
+        return isLiked;
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/PlanDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/PlanDetailResponse.java
@@ -1,5 +1,7 @@
 package com.wemo.backend.domain.review.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.wemo.backend.domain.meeting.dto.MeetingInfoResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
@@ -54,13 +56,37 @@ public class PlanDetailResponse {
     
     private MeetingInfoResponse meetingInfo;
 
+    @JsonProperty("isCanceled")
     private boolean isCanceled;
 
+    @JsonProperty("isLiked")
     private boolean isLiked;
 
+    @JsonProperty("isOpened")
     private boolean isOpened;
 
+    @JsonProperty("isFulled")
     private boolean isFulled;
+
+    @JsonProperty("isCanceled")
+    public boolean getIsCanceled() {
+        return isCanceled;
+    }
+
+    @JsonProperty("isLiked")
+    public boolean getIsLiked() {
+        return isLiked;
+    }
+
+    @JsonProperty("isOpened")
+    public boolean getIsOpened() {
+        return isOpened;
+    }
+
+    @JsonProperty("isFulled")
+    public boolean getIsFulled() {
+        return isFulled;
+    }
 
     public static PlanDetailResponse fromEntity(Plan plan, String planImagePath, Meeting meeting, int participants, int likeCount, List<UserListInfo> userList, MeetingInfoResponse meetingInfoResponse, boolean isLiked) {
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- `boolean` 타입 필드의 JSON 직렬화 명칭을 API 명세에 맞게 수정하였습니다.
- `@JsonProperty`을 사용하여 반환될 컬럼명을 명시하였습니다.
- Lombok의 `@Getter` 자동 생성 기능과 중복 발생을 방지하기 위해, 특정 필드에 대해 직접 게터를 정의하였습니다. 이를 통해 JSON 직렬화 시 원하는 컬럼명을 유지할 수 있도록 처리하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/plan-deatil-25 -> dev
- close #25 

<br/>

## 🔥 트러블 슈팅 (선택)
- 문제: 
   - Jackson은 기본적으로 Java Bean 규약에 따라 `boolean` 필드 직렬화 시 is 접두사를 제거한 이름으로 처리 
   - 이는 API 명세와 일치하지 않아 수정이 필요

   -> 해결 : `@JsonProperty`로 명시적으로 반환될 컬럼명을 설정하고, 해당 필드의 게터를 직접 정의하여 원하는 JSON 응답 구조를 구현
