### PR TITLE
[Feat] 후기 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -50,6 +50,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             }
 
+            if (requestURI.startsWith("/api/reviews") && "GET".equalsIgnoreCase(method)) {
+                // 토큰이 없는 경우 비회원으로 처리
+                if (accessToken == null) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            }
+
             // 로그아웃 요청 처리
             if ("/api/auths/signout".equals(requestURI)) {
                 if (!validateLogoutRequest(accessToken, refreshToken, response)) {

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -213,5 +213,4 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         log.info("모임의 모집 마감 상태가 {} 번 업데이트되었습니다.", updatedCount);
     }
 
-
 }

--- a/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.review.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
 import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import com.wemo.backend.domain.review.dto.ReviewPagingResponse;
 import com.wemo.backend.domain.review.service.ReviewService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,6 +13,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -37,6 +41,24 @@ public class ReviewController {
                                                                               @PathVariable Long planId,
                                                                               @Valid @RequestBody ReviewCreateRequest request) {
         return ResponseEntity.status(201).body(SuccessResponse.successWithData(reviewService.createReview(userDetails.getUsername(), planId, request)));
+    }
+
+    @Operation(summary = "후기 목록 조회", description = "회원 또는 비회원이 요청하는 후기의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 후기 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<ReviewPagingResponse>> getHeartList(@RequestParam(defaultValue = "1") int page,
+                                                                              @RequestParam int size,
+                                                                              @RequestParam(required = false) String province,
+                                                                              @RequestParam(required = false) String district,
+                                                                              @RequestParam(required = false) String startDate,
+                                                                              @RequestParam(required = false) String endDate,
+                                                                              @RequestParam(required = false) Long categoryId,
+                                                                              @RequestParam(required = false) String sort) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(reviewService.getReviewList(pageable, province, district, startDate, endDate, categoryId, sort)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
@@ -1,0 +1,38 @@
+package com.wemo.backend.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class ReviewListResponse {
+
+    private Long planId;
+
+    private String planName;
+
+    private String planImagePath;
+
+    private String category;
+
+    private String address;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private Long reviewId;
+
+    private int score;
+
+    private String comment;
+
+    private String reviewImagePath;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewPagingResponse.java
@@ -1,0 +1,33 @@
+package com.wemo.backend.domain.review.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReviewPagingResponse {
+
+    private int reviewCount;
+
+    private List<?> reviewList;
+
+    private int pageSize;
+
+    private int page;
+
+    private int totalPage;
+
+    public ReviewPagingResponse(Page<ReviewListResponse> reviewList) {
+
+        this.reviewCount = (int) reviewList.getTotalElements();
+        this.reviewList = reviewList.getContent();
+        this.pageSize = reviewList.getSize();
+        this.page = reviewList.getPageable().getPageNumber() + 1;
+        this.totalPage = reviewList.getTotalPages();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -2,12 +2,13 @@ package com.wemo.backend.domain.review.repository;
 
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.repository.querydsl.ReviewQueryDsl;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface ReviewRepository extends JpaRepository<Review, Long> {
+public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
 
     boolean existsByUserAndPlan(User user, Plan plan);
 

--- a/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDsl.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.review.repository.querydsl;
+
+import com.wemo.backend.domain.review.dto.ReviewListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface ReviewQueryDsl {
+
+    Page<ReviewListResponse> getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
@@ -1,0 +1,152 @@
+package com.wemo.backend.domain.review.repository.querydsl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.review.dto.ReviewListResponse;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import static com.querydsl.jpa.JPAExpressions.select;
+import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.plan.entity.QPlan.plan;
+import static com.wemo.backend.domain.review.entity.QReview.review;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+@Slf4j
+public class ReviewQueryDslImpl implements ReviewQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public ReviewQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<ReviewListResponse> getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        JPAQuery<ReviewListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                ReviewListResponse.class,
+                                plan.id,
+                                plan.planName,
+                                Expressions.as(
+                                        select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN)),
+                                        "planImagePath"
+                                ),
+                                plan.meeting.category.categoryName,
+                                plan.address,
+                                user.nickname,
+                                user.profileImagePath,
+                                review.id,
+                                review.score,
+                                review.comment,
+                                Expressions.as(
+                                        select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(review.id),
+                                                        image.entityType.eq(Image.EntityType.REVIEW)),
+                                        "reviewImagePath"
+                                ),
+                                review.createdAt,
+                                review.updatedAt
+                        )
+                )
+                .from(review)
+                .leftJoin(review.plan, plan)
+                .leftJoin(review.user, user);
+
+        // 필터링 적용
+        applyFilters(queryBuilder, province, district, startDate, endDate, categoryId, sort);
+
+        // 페이징 적용
+        List<ReviewListResponse> reviewDetailInfoList = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(review.count())
+                        .from(review)
+                        .leftJoin(review.plan, plan)
+                        .leftJoin(review.user, user)
+                        .where(applyFiltersForTotalCount(province, district, startDate, endDate, categoryId)) // 필터를 적용한 메서드 호출
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(reviewDetailInfoList, pageable, total);
+
+    }
+
+    // 필터링 적용
+    private void applyFilters(JPAQuery<ReviewListResponse> queryBuilder, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        if (province != null && !province.isEmpty()) {
+            queryBuilder.where(plan.district.province.provinceName.contains(province));
+        }
+
+        if (district != null && !district.isEmpty()) {
+            queryBuilder.where(plan.district.districtName.eq(district));
+        }
+
+        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            queryBuilder.where(review.createdAt.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (categoryId != null) {
+            queryBuilder.where(plan.meeting.category.id.eq(categoryId));
+        }
+
+        // 정렬 조건 적용
+        if ("ratingOrder".equals(sort)) {
+            queryBuilder.orderBy(review.score.desc());
+        } else {
+            queryBuilder.orderBy(review.createdAt.desc());
+        }
+    }
+
+    // 필터링된 총 개수를 위한 메서드
+    private BooleanBuilder applyFiltersForTotalCount(String province, String district, String startDate, String endDate, Long categoryId) {
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (province != null && !province.isEmpty()) {
+            builder.and(plan.district.province.provinceName.contains(province));
+        }
+
+        if (district != null && !district.isEmpty()) {
+            builder.and(plan.district.districtName.eq(district));
+        }
+
+        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            builder.and(review.createdAt.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (categoryId != null) {
+            builder.and(plan.meeting.category.id.eq(categoryId));
+        }
+
+        return builder;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
@@ -1,12 +1,17 @@
 package com.wemo.backend.domain.review.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
 import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import com.wemo.backend.domain.review.dto.ReviewPagingResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface ReviewService {
 
     ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request);
+
+    ReviewPagingResponse getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort);
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -1,11 +1,13 @@
 package com.wemo.backend.domain.review.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.service.PlanReader;
 import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
 import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
+import com.wemo.backend.domain.review.dto.ReviewPagingResponse;
 import com.wemo.backend.domain.review.entity.Review;
 import com.wemo.backend.domain.review.repository.ReviewRepository;
 import com.wemo.backend.domain.user.entity.User;
@@ -13,6 +15,7 @@ import com.wemo.backend.domain.user.service.UserReader;
 import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -74,6 +77,24 @@ public class ReviewServiceImpl implements ReviewService {
         }
         return ReviewCreateResponse.fromEntity(plan, review);
 
+    }
+
+    /**
+     * 전체 후기 목록 조회 (페이지 기반 페이징처리)
+     *
+     * @param pageable 페이징 관련 데이터
+     * @param province 시/도
+     * @param district 군/구
+     * @param startDate 필터링 시작날짜
+     * @param endDate 필터링 끝날짜
+     * @param categoryId 카테고리 id
+     * @param sort 정렬 기준
+     * @return 페이징 처리된 후기 목록
+     */
+    @Override
+    public ReviewPagingResponse getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        return new ReviewPagingResponse(reviewRepository.getReviewList(pageable, province, district, startDate, endDate, categoryId, sort));
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -21,6 +21,8 @@ import org.springframework.web.cors.CorsConfiguration;
 import java.util.Arrays;
 import java.util.Collections;
 
+import static org.springframework.http.HttpMethod.GET;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -87,8 +89,9 @@ public class SecurityConfig {
                                 "/v3/api-docs/**"
                                 ).permitAll()
                                 // 비회원 허용 경로
-                                .requestMatchers(HttpMethod.GET, "/api/meetings/**").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/plans/**").permitAll()
+                                .requestMatchers(GET, "/api/meetings/**").permitAll()
+                                .requestMatchers(GET, "/api/plans/**").permitAll()
+                                .requestMatchers(GET, "/api/reviews/**").permitAll()
 
                                 .anyRequest().authenticated()
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 후기 목록 조회 기능 구현하였습니다.
- 페이지 기반 페이징 처리로 구현하였습니다.
- 기간, 지역 및 카테고리에 따른 필터링 설정하였습니다.
- 정렬 기준은 기본 최신순이며, 후기 평점 좋은 순으로 구현되어 있습니다. `찜 많은 순의 경우 추가 논의 후 수정할 예정입니다.`

<br/>

## 🌱 반영 브랜치
- feat/review-list-28 -> dev
- close #28 

<br/>
