### PR TITLE
[Feat] 내 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -42,6 +42,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
+            if (requestURI.startsWith("/api/meetings") && "GET".equalsIgnoreCase(method)) {
+                // 토큰이 없는 경우 비회원으로 처리
+                if (accessToken == null) {
+                    filterChain.doFilter(request, response);
+                    return;
+                }
+            }
+
             if (requestURI.startsWith("/api/plans") && "GET".equalsIgnoreCase(method)) {
                 // 토큰이 없는 경우 비회원으로 처리
                 if (accessToken == null) {
@@ -151,8 +159,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/api/auths/signup") ||
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
-                requestURI.startsWith("/v3/api-docs") ||
-                requestURI.startsWith("/api/meetings");
+                requestURI.startsWith("/v3/api-docs");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -8,6 +8,7 @@ import com.wemo.backend.domain.like.repository.LikeRepository;
 import com.wemo.backend.domain.meeting.dto.MeetingInfoResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.service.MeetingReader;
+import com.wemo.backend.domain.meeting.service.MeetingStore;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
@@ -59,6 +60,8 @@ public class PlanServiceImpl implements PlanService {
     private final LikeRepository likeRepository;
 
     private final ImageReader imageReader;
+
+    private final MeetingStore meetingStore;
 
     /**
      * 0. 일정 생성
@@ -123,6 +126,9 @@ public class PlanServiceImpl implements PlanService {
 
         planStore.joinPlan(user, plan);
 
+        // 일정 참여 시 모임에도 자동으로 가입
+        meetingStore.joinMeeting(user, plan.getMeeting());
+
         return "일정 참여 신청 완료되었습니다.";
     }
 
@@ -159,7 +165,6 @@ public class PlanServiceImpl implements PlanService {
 
         int likeCount = likeRepository.countByPlan(plan);
         boolean isLiked = isPlanLikedByUser(userDetails, plan);
-        log.info("일정에 대한 좋아요 여부 : {}", isLiked);
 
         // 일정으로 모임 정보 생성
         MeetingInfoResponse meetingInfoResponse = getMeetingInfoResponse(plan);
@@ -191,7 +196,6 @@ public class PlanServiceImpl implements PlanService {
         }
 
         User user = userReader.getUserByEmail(userDetails.getUsername());
-        log.info("일정 상세 조회 시 유저 존재 : {}", user.getEmail());
         return likeRepository.existsByUserAndPlan(user, plan);
     }
 

--- a/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
@@ -48,7 +48,7 @@ public class ReviewController {
             @ApiResponse(responseCode = "200", description = "요청한 후기 목록이 반환되었습니다.")
     })
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public ResponseEntity<SuccessResponse<ReviewPagingResponse>> getHeartList(@RequestParam(defaultValue = "1") int page,
+    public ResponseEntity<SuccessResponse<ReviewPagingResponse>> getReviewList(@RequestParam(defaultValue = "1") int page,
                                                                               @RequestParam int size,
                                                                               @RequestParam(required = false) String province,
                                                                               @RequestParam(required = false) String district,

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -1,0 +1,43 @@
+package com.wemo.backend.domain.user.controller;
+
+import com.wemo.backend.domain.auth.UserDetailsImpl;
+import com.wemo.backend.domain.user.dto.UserMeetingPagingResponse;
+import com.wemo.backend.domain.user.service.UserService;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Users")
+@RestController
+@RequestMapping("/api/users")
+@RequiredArgsConstructor
+public class UserDashboardController {
+
+    private final UserService userService;
+
+    @Operation(summary = "내 모임 목록 조회", description = "유저가 속한 모임의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 속한 모임 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/meetings", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserMeetingPagingResponse>> getMyMeetingList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                       @RequestParam(defaultValue = "1") int page,
+                                                                                       @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyMeetingList(userDetails.getUsername(), pageable)));
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingListResponse.java
@@ -1,0 +1,26 @@
+package com.wemo.backend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserMeetingListResponse {
+
+    private String email;
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String category;
+
+    private Long memberCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingPagingResponse.java
@@ -1,0 +1,33 @@
+package com.wemo.backend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UserMeetingPagingResponse {
+
+    private int meetingCount;
+
+    private List<?> meetingList;
+
+    private int pageSize;
+
+    private int page;
+
+    private int totalPage;
+
+    public UserMeetingPagingResponse(Page<UserMeetingListResponse> meetingList) {
+
+        this.meetingCount = (int) meetingList.getTotalElements();
+        this.meetingList = meetingList.getContent();
+        this.pageSize = meetingList.getSize();
+        this.page = meetingList.getPageable().getPageNumber() + 1;
+        this.totalPage = meetingList.getTotalPages();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/UserRepository.java
@@ -1,12 +1,13 @@
 package com.wemo.backend.domain.user.repository;
 
 import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.domain.user.repository.querydsl.UserQueryDsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 import java.util.UUID;
 
-public interface UserRepository extends JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID>, UserQueryDsl {
 
     Optional<User> findByEmail(String username);
 

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.user.repository.querydsl;
+
+import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface UserQueryDsl {
+
+    Page<UserMeetingListResponse> getUserMeetingList(String email, Pageable pageable);
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -1,0 +1,81 @@
+package com.wemo.backend.domain.user.repository.querydsl;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
+import static com.wemo.backend.domain.meeting.entity.QMeetingMember.meetingMember;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+public class UserQueryDslImpl implements UserQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public UserQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<UserMeetingListResponse> getUserMeetingList(String email, Pageable pageable) {
+
+        // 메인 쿼리
+        JPAQuery<UserMeetingListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserMeetingListResponse.class,
+                                meeting.user.email, // meeting.user.email 참조
+                                meeting.id,
+                                meeting.meetingName,
+                                meeting.category.categoryName,
+                                Expressions.as(
+                                        JPAExpressions.select(meetingMember.count())
+                                                .from(meetingMember)
+                                                .where(meetingMember.meeting.id.eq(meeting.id)
+                                                        .and(meetingMember.deletedAt.isNull())),
+                                        "memberCount"
+                                ),
+                                meeting.createdAt,
+                                meeting.updatedAt
+                        )
+                )
+                .from(meeting)
+                .leftJoin(meeting.user, user)
+                .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
+                .where(meeting.user.email.eq(email) // 유저가 작성한 모임
+                        .or(meetingMember.user.email.eq(email))) // 유저가 가입한 모임
+                .groupBy(meeting.id) // 그룹화
+                .orderBy(meeting.createdAt.desc());
+
+        // 페이징 처리
+        List<UserMeetingListResponse> userMeetingListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 총 갯수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                .select(meeting.count())
+                .from(meeting)
+                .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
+                .where(meeting.user.email.eq(email)
+                    .or(meetingMember.user.email.eq(email)))
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(userMeetingListResponses, pageable, total);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -3,6 +3,8 @@ package com.wemo.backend.domain.user.service;
 import com.wemo.backend.domain.user.dto.SigninRequest;
 import com.wemo.backend.domain.user.dto.UserCreateRequest;
 import com.wemo.backend.domain.user.dto.UserInfoResponse;
+import com.wemo.backend.domain.user.dto.UserMeetingPagingResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
@@ -18,5 +20,7 @@ public interface UserService {
      String signout(String accessToken, String refreshToken);
 
     UserInfoResponse getUserInfo(String email);
+
+    UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -9,10 +9,13 @@ import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
 import com.wemo.backend.domain.user.dto.SigninRequest;
 import com.wemo.backend.domain.user.dto.UserCreateRequest;
 import com.wemo.backend.domain.user.dto.UserInfoResponse;
+import com.wemo.backend.domain.user.dto.UserMeetingPagingResponse;
 import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +31,8 @@ public class UserServiceImpl implements UserService {
     private final TokenBlacklistService tokenBlacklistService;
     private final RefreshTokenManager refreshTokenManager;
     private final RefreshTokenRepository refreshTokenRepository;
+
+    private final UserRepository userRepository;
 
     /**
      * 0. 이메일 중복 검사
@@ -111,6 +116,12 @@ public class UserServiceImpl implements UserService {
 
         User user = userReader.getUserByEmail(email);
         return UserInfoResponse.fromEntity(user);
+    }
+
+    @Override
+    public UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable) {
+
+        return new UserMeetingPagingResponse(userRepository.getUserMeetingList(email, pageable));
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 유저가 속한 모임에 대한 목록 조회 기능을 구현했습니다.
  - 유저가 만든 모임과 가입된 모임을 모두 포함하여 반환합니다.
  - 최신순으로 정렬된 목록을 제공합니다.
- 모임 관련 API 내에서 토큰이 없는 비회원은 GET 요청만 가능하도록 필터 단에서 코드 수정하였습니다.
(토큰이 존재하는 경우에는 추가적인 처리 로직을 포함할 수 있도록 설정)
- 일정 참여 시 모임에도 자동으로 가입되도록 로직 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/user-meeting-30 -> dev
- close #30 

<br/>

## 🔥 트러블 슈팅 (선택)
- 문제점:
   `meetingMember`와 조인 시 관계를 제대로 해석하지 못해 `Could not resolve join path` 예외가 발생했습니다.
- 해결 방법:
  `on` 절을 사용하여 명시적으로 `meetingMember`와 `meeting` 간의 관계를 설정했습니다. 이를 통해 QueryDSL에서 조인 관계를 올바르게 처리할 수 있었습니다.
