### PR TITLE
[Feat] 내가 작성한 후기 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.user.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.user.dto.UserMeetingPagingResponse;
 import com.wemo.backend.domain.user.dto.UserPlanPagingResponse;
+import com.wemo.backend.domain.user.dto.UserReviewPagingResponse;
 import com.wemo.backend.domain.user.service.UserService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,4 +57,20 @@ public class UserDashboardController {
         return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyPlanList(userDetails.getUsername(), pageable)));
 
     }
+
+    @Operation(summary = "내가 작성한 후기 목록 조회", description = "유저가 작성한 후기의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 작성한 후기의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/reviews", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserReviewPagingResponse>> getMyReviewList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                     @RequestParam(defaultValue = "1") int page,
+                                                                                     @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyReviewList(userDetails.getUsername(), pageable)));
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
@@ -1,0 +1,32 @@
+package com.wemo.backend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserReviewListResponse {
+
+    private Long reviewId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private String category;
+
+    private String address;
+
+    private int score;
+
+    private String comment;
+
+    private String reviewImagePath;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserReviewPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserReviewPagingResponse.java
@@ -1,0 +1,32 @@
+package com.wemo.backend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UserReviewPagingResponse {
+
+        private int reviewCount;
+
+        private List<?> reviewList;
+
+        private int pageSize;
+
+        private int page;
+
+        private int totalPage;
+
+        public UserReviewPagingResponse(Page<UserReviewListResponse> reviewListResponses) {
+
+            this.reviewCount = (int) reviewListResponses.getTotalElements();
+            this.reviewList = reviewListResponses.getContent();
+            this.pageSize = reviewListResponses.getSize();
+            this.page = reviewListResponses.getPageable().getPageNumber() + 1;
+            this.totalPage = reviewListResponses.getTotalPages();
+
+        }
+}

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.user.repository.querydsl;
 
 import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
 import com.wemo.backend.domain.user.dto.UserPlanListResponse;
+import com.wemo.backend.domain.user.dto.UserReviewListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -10,5 +11,7 @@ public interface UserQueryDsl {
     Page<UserMeetingListResponse> getUserMeetingList(String email, Pageable pageable);
 
     Page<UserPlanListResponse> getUserPlanList(String email, Pageable pageable);
+
+    Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -6,8 +6,10 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.review.entity.QReview;
 import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
 import com.wemo.backend.domain.user.dto.UserPlanListResponse;
+import com.wemo.backend.domain.user.dto.UserReviewListResponse;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +20,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wemo.backend.domain.category.entity.QCategory.category;
 import static com.wemo.backend.domain.image.entity.QImage.image;
 import static com.wemo.backend.domain.like.entity.QLike.like;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
@@ -26,6 +29,7 @@ import static com.wemo.backend.domain.plan.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
 import static com.wemo.backend.domain.region.entity.QDistrict.district;
 import static com.wemo.backend.domain.region.entity.QProvince.province;
+import static com.wemo.backend.domain.review.entity.QReview.review;
 import static com.wemo.backend.domain.user.entity.QUser.user;
 
 @Slf4j
@@ -200,6 +204,61 @@ public class UserQueryDslImpl implements UserQueryDsl {
         ).orElse(0L);
 
         return new PageImpl<>(planListResponses, pageable, total);
+
+    }
+
+    @Override
+    public Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable) {
+
+        JPAQuery<UserReviewListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserReviewListResponse.class,
+                                review.id,
+                                review.plan.planName,
+                                review.plan.dateTime,
+                                category.categoryName,
+                                review.plan.address,
+                                review.score,
+                                review.comment,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(review.id),
+                                                        image.entityType.eq(Image.EntityType.REVIEW)),
+                                        "reviewImagePath"
+                                ),
+                                review.createdAt,
+                                review.updatedAt
+                        )
+                )
+                .from(review)
+                .leftJoin(review.plan, plan)
+                .leftJoin(plan.meeting, meeting)  // meeting과 조인
+                .leftJoin(meeting.category, category)  // category와 조인
+                .leftJoin(image).on(image.entityId.eq(review.id) // Image 엔티티와 review.id를 조인
+                        .and(image.entityType.eq(Image.EntityType.REVIEW)))
+                .where(review.user.email.eq(email)) // 유저가 작성한 후기만
+                .orderBy(review.createdAt.desc());
+
+        List<UserReviewListResponse> reviewListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 총 개수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(review.count())
+                        .from(review)
+                        .leftJoin(review.plan, plan)
+                        .leftJoin(plan.meeting, meeting)
+                        .leftJoin(meeting.category, category)
+                        .where(review.user.email.eq(email))
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(reviewListResponses, pageable, total);
 
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -22,4 +22,6 @@ public interface UserService {
 
     UserPlanPagingResponse getMyPlanList(String email, Pageable pageable);
 
+    UserReviewPagingResponse getMyReviewList(String email, Pageable pageable);
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -133,12 +133,25 @@ public class UserServiceImpl implements UserService {
      *
      * @param email 이메일
      * @param pageable 페이징 처리 데이터
-     * @return 유저가 참여한 일정 목록 조회
+     * @return 유저가 참여한 일정 목록
      */
     @Override
     public UserPlanPagingResponse getMyPlanList(String email, Pageable pageable) {
 
         return new UserPlanPagingResponse(userRepository.getUserPlanList(email, pageable));
+    }
+
+    /**
+     * 내가 쓴 후기 목록 조회
+     *
+     * @param email 이메일
+     * @param pageable 페이징 처리 데이터
+     * @return 유저가 작성한 후기 목록
+     */
+    @Override
+    public UserReviewPagingResponse getMyReviewList(String email, Pageable pageable) {
+
+        return new UserReviewPagingResponse(userRepository.getUserReviewList(email, pageable));
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 유저가 작성한 후기 목록을 반환하는 API를 구현하였습니다.
- 페이지 기반 페이징 처리로 데이터의 효율적 조회를 지원합니다.

<br/>

## 🌱 반영 브랜치
- `feat/user-review-35` → `dev`

<br/>

## 🔥 트러블 슈팅 (선택)
### 문제
- QueryDSL로 Join을 설정하는 과정에서, 후기(review)에는 직접적으로 카테고리(category)가 연결되어 있지 않아 다중 조인이 필요했습니다.

### 해결
- **`on` 절을 활용한 Join**:
  - 후기(review) → 플랜(plan) → 모임(meeting) → 카테고리(category) 순서로 연결되는 관계를 명시적으로 정의.
  - QueryDSL의 `leftJoin`과 `on` 절을 조합하여 필요한 데이터를 효율적으로 조회하였습니다.
