### PR TITLE
[Feat] 리뷰 작성 가능한 일정 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Attendance.java
@@ -33,4 +33,16 @@ public class Attendance extends Timestamped {
     @Comment("일정 id")
     private Plan plan;
 
+    @Column(name = "is_reviewed", nullable = false)
+    @Comment("후기 작성 여부")
+    @Builder.Default
+    private boolean reviewed = false;
+
+
+    public void updateStatus() {
+
+        this.reviewed = true;
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/AttendanceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/AttendanceRepository.java
@@ -6,8 +6,11 @@ import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
+
+    Optional<Attendance> findByUserAndPlan(User user, Plan plan);
 
     boolean existsByUserAndPlan(User user, Plan plan);
 

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
@@ -11,7 +11,7 @@ public interface PlanReader {
 
     Plan getPlan(Long planId);
 
-    void validateAttendance(User user, Plan plan);
+    Attendance validateAttendance(User user, Plan plan);
 
     List<Plan> getPlanByMeeting(Meeting meeting);
 

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
@@ -31,12 +31,11 @@ public class PlanReaderImpl implements PlanReader {
     }
 
     @Override
-    public void validateAttendance(User user, Plan plan) {
+    public Attendance validateAttendance(User user, Plan plan) {
 
-        boolean exists = attendanceRepository.existsByUserAndPlan(user, plan);
-
-        if (!exists) throw new CustomException(PLAN_ATTENDANCE_NOT_FOUND);
-
+        return attendanceRepository.findByUserAndPlan(user, plan).orElseThrow(
+                () -> new CustomException(PLAN_ATTENDANCE_NOT_FOUND)
+        );
     }
 
     @Override

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.review.service;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageStore;
+import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.service.PlanReader;
 import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
@@ -59,13 +60,14 @@ public class ReviewServiceImpl implements ReviewService {
             throw new CustomException(REVIEW_ALREADY_EXISTS);
         }
 
-        // 참여 내역 검사
-        planReader.validateAttendance(user, plan);
-
         // 일정이 완료되었는지 확인
         if (plan.getDateTime().isAfter(LocalDateTime.now())) {
             throw new CustomException(REVIEW_CREATION_BEFORE_PLAN_END);
         }
+
+        // 참여 내역 검사 후 상태값 변경
+        Attendance attendance = planReader.validateAttendance(user, plan);
+        attendance.updateStatus();
 
         // 후기 저장
         Review review = reviewStore.storeReview(request, user, plan);

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -73,4 +73,19 @@ public class UserDashboardController {
 
     }
 
+    @Operation(summary = "후기 작성 가능한 일정 목록 조회", description = "후기 작성 가능한 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "후기 작성 가능한 일정의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/reviews/available", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getPlanListReviewAvailable(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                 @RequestParam(defaultValue = "1") int page,
+                                                                                 @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getPlanListReviewAvailable(userDetails.getUsername(), pageable)));
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserPlanPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserPlanPagingResponse.java
@@ -20,7 +20,7 @@ public class UserPlanPagingResponse {
 
     private int totalPage;
 
-    public UserPlanPagingResponse(Page<UserPlanListResponse> userPlanList) {
+    public UserPlanPagingResponse(Page<?> userPlanList) {
 
         this.planCount = (int) userPlanList.getTotalElements();
         this.planList = userPlanList.getContent();

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserPlanReviewableListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserPlanReviewableListResponse.java
@@ -1,0 +1,32 @@
+package com.wemo.backend.domain.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserPlanReviewableListResponse {
+
+    private Long planId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private String category;
+
+    private String address;
+
+    private String planImagePath;
+
+    private int capacity;
+
+    private Long participants;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.user.repository.querydsl;
 
 import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
 import com.wemo.backend.domain.user.dto.UserPlanListResponse;
+import com.wemo.backend.domain.user.dto.UserPlanReviewableListResponse;
 import com.wemo.backend.domain.user.dto.UserReviewListResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,5 +14,7 @@ public interface UserQueryDsl {
     Page<UserPlanListResponse> getUserPlanList(String email, Pageable pageable);
 
     Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable);
+
+    Page<UserPlanReviewableListResponse> getUserPlanListReviewAvailable(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -9,6 +9,7 @@ import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.review.entity.QReview;
 import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
 import com.wemo.backend.domain.user.dto.UserPlanListResponse;
+import com.wemo.backend.domain.user.dto.UserPlanReviewableListResponse;
 import com.wemo.backend.domain.user.dto.UserReviewListResponse;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
@@ -260,6 +261,74 @@ public class UserQueryDslImpl implements UserQueryDsl {
 
         return new PageImpl<>(reviewListResponses, pageable, total);
 
+    }
+
+    @Override
+    public Page<UserPlanReviewableListResponse> getUserPlanListReviewAvailable(String email, Pageable pageable) {
+
+        JPAQuery<UserPlanReviewableListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserPlanReviewableListResponse.class,
+                                plan.id,
+                                plan.planName,
+                                plan.dateTime,
+                                category.categoryName,
+                                plan.address,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN)),
+                                        "planImagePath"
+                                ),
+                                plan.capacity,
+                                Expressions.as(
+                                        queryFactory.select(attendance.count())
+                                                .from(attendance)
+                                                .where(attendance.plan.id.eq(plan.id)
+                                                        .and(attendance.deletedAt.isNull())),
+                                        "participants"
+                                ),
+                                plan.createdAt,
+                                plan.updatedAt
+                        )
+                )
+                .from(attendance) // attendance 테이블을 from 절에서 시작
+                .leftJoin(attendance.plan, plan) // plan과 조인
+                .leftJoin(plan.meeting, meeting)
+                .leftJoin(meeting.category, category)
+                .leftJoin(attendance.user, user) // user와 조인
+                .where(
+                        attendance.user.email.eq(email) // 이메일 조건
+                                .and(attendance.reviewed.eq(false)) // 후기 미작성
+                                .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
+                )
+                .orderBy(plan.createdAt.desc());
+
+        List<UserPlanReviewableListResponse> reviewListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 총 개수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(plan.count())
+                        .from(attendance) // attendance 테이블을 from 절에서 시작
+                        .leftJoin(attendance.plan, plan) // plan과 조인
+                        .leftJoin(plan.meeting, meeting)
+                        .leftJoin(meeting.category, category)
+                        .leftJoin(attendance.user, user) // user와 조인
+                        .where(
+                                attendance.user.email.eq(email) // 이메일 조건
+                                        .and(attendance.reviewed.eq(false)) // 후기 미작성
+                                        .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
+                        )
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(reviewListResponses, pageable, total);
     }
 
     private void updateIsFulledStatus() {

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -24,4 +24,6 @@ public interface UserService {
 
     UserReviewPagingResponse getMyReviewList(String email, Pageable pageable);
 
+    UserPlanPagingResponse getPlanListReviewAvailable(String email, Pageable pageable);
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -154,4 +154,17 @@ public class UserServiceImpl implements UserService {
         return new UserReviewPagingResponse(userRepository.getUserReviewList(email, pageable));
     }
 
+    /**
+     * 후기 작성 가능한 일정 목록 조회
+     *
+     * @param email 이메일
+     * @param pageable 페이징 처리 데이터
+     * @return 후기 작성 가능한 일정 목록
+     */
+    @Override
+    public UserPlanPagingResponse getPlanListReviewAvailable(String email, Pageable pageable) {
+
+        return new UserPlanPagingResponse(userRepository.getUserPlanListReviewAvailable(email, pageable));
+    }
+
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
1. 후기 작성 가능 일정 목록 반환
  - 참여한 일정 중 후기 작성 여부를 기준으로 필터링하여 반환
  - 페이지 기반 페이징 처리로 응답 데이터 구성

2. 참여 내역 테이블 수정
  - `reviewed` 컬럼 추가: 후기 작성 여부 판단을 위해 활용
  
3. 후기 등록 로직 개선
  - 후기 등록 시 해당 일정의 `Attendance.reviewed`를 `true`로 업데이트하도록 수정
  
4. 후기 작성 가능 일정 쿼리
  - 후기 미작성(reviewed = false) 일정만 반환되도록 설정

<br/>

## 🌱 반영 브랜치
- feat/user-reviewable-36 -> dev
- close #36 

<br/>

## 🔥 트러블 슈팅 (선택)
### 1 : QueryDSL 조인 문제
   초기 구현에서 복잡한 연관관계 설정으로 경로 탐색 오류 발생
   -> 해결: attendance를 기준으로 user와 plan을 조인하여 경로를 명확히 탐색

### 2. reviewed 컬럼 추가

   기존 쿼리 조건의 복잡성을 줄이기 위해 Attendance 엔티티에 reviewed 컬럼을 추가
   후기 작성 여부를 명확히 판단할 수 있도록 데이터 모델 개선