### PR TITLE
[Chore] 배포 세팅

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM openjdk:17-jdk-alpine
+
+# 필요한 패키지 설치
+RUN apk add --no-cache tzdata
+
+# 타임존 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ARG JAR_PATH=build/libs/*.jar
+COPY ${JAR_PATH} app.jar
+
+ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=prod", "app.jar"]

--- a/src/main/java/com/wemo/backend/global/config/RedisConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.wemo.backend.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${REDIS_HOST}")
+    private String redisHost;
+
+    @Value("${REDIS_PORT}")
+    private int redisPort;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new StringRedisSerializer());
+        return template;
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용 (필수)
1. **도커파일 생성**  
   - 애플리케이션 배포를 위한 `Dockerfile`을 작성하였습니다.  

2. **Redis 설정 파일 추가**  
   - 배포 환경에서 Redis와의 원활한 연동을 위해 Redis 설정 파일 (`RedisConfig`)을 추가하였습니다.  

<br/>

## 🌱 반영 브랜치
- `chore/prod-setting-32` -> `dev`
- close #32  

<br/>

## 🔥 트러블 슈팅 (선택)
1. **문제 상황**  
   - 로컬 환경에서는 별도의 `RedisConfig` 없이도 Redis 연결이 정상적으로 이루어졌으나, 배포 환경에서는 Redis와 연결 오류가 발생
   - Docker 컨테이너로 Redis를 실행하고, `ping-pong` 테스트를 통해 Redis 서버가 동작 중임을 확인했음에도 연결되지 않음

2. **해결 과정**  
   - 네트워크를 `bridge` 모드로 설정해도 문제 해결이 되지 않아 추가로 원인을 탐색
   - 구글링 결과, 배포 환경에서는 명시적인 Redis 설정이 필요하다는 사례를 발견
   - 애플리케이션에 `RedisConfig` 파일을 추가하여 Redis 연결 설정을 명시적으로 작성함으로써 문제 해결

<br/>
