### PR TITLE
[Feat] 모임 수정 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.meeting.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
 import com.wemo.backend.domain.meeting.service.MeetingService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -58,6 +59,19 @@ public class MeetingController {
     @RequestMapping(value = "/{meetingId}", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<MeetingDetailResponse>> getMeetingDetail(@PathVariable Long meetingId) {
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getMeetingDetail(meetingId)));
+    }
+
+    @Operation(summary = "모임 정보 수정", description = "모임 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모임 정보가 수정되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{meetingId}", method = RequestMethod.PATCH)
+    public ResponseEntity<SuccessResponse<String>> updateMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                 @PathVariable Long meetingId,
+                                                                 @Valid @RequestBody MeetingUpdateRequest request) {
+        return ResponseEntity.ok(SuccessResponse.successWithNoData(meetingService.updateMeeting(userDetails.getUsername(), meetingId, request)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingUpdateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+@Getter
+public class MeetingUpdateRequest {
+
+    @Size(min = 8, max = 500, message = "모임 설명은 8자 이상 500자 이하입니다.")
+    private String description;
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/entity/Meeting.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/entity/Meeting.java
@@ -42,4 +42,10 @@ public class Meeting extends Timestamped {
     @Comment("유저 id")
     private User user;
 
+    public void updateDescription(String description) {
+
+        this.description = description;
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -12,5 +13,7 @@ public interface MeetingService {
     String joinMeeting(String email, Long meetingId);
 
     MeetingDetailResponse getMeetingDetail(Long meetingId);
+
+    String updateMeeting(String email, Long meetingId, MeetingUpdateRequest request);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -5,6 +5,7 @@ import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.dto.PlanListInfo;
 import com.wemo.backend.domain.plan.entity.Attendance;
@@ -16,6 +17,7 @@ import com.wemo.backend.domain.review.service.ReviewReader;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
+import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,6 +25,8 @@ import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_GRANTED;
 
 @Service
 @RequiredArgsConstructor
@@ -113,6 +117,29 @@ public class MeetingServiceImpl implements MeetingService {
                 reviewListInfoList.size(),
                 reviewListInfoList
         );
+    }
+
+    /**
+     * 모임 정보 수정
+     *
+     * @param email 이메일
+     * @param meetingId 모임 id
+     * @param request 수정 요청 데이터 (모임 설명)
+     * @return 성공 메세지
+     */
+    @Override
+    @Transactional
+    public String updateMeeting(String email, Long meetingId, MeetingUpdateRequest request) {
+
+        User user = userReader.getUserByEmail(email);
+
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+
+        if (!meeting.getUser().getEmail().equals(user.getEmail())) throw new CustomException(ILLEGAL_MEETING_GRANTED);
+
+        meeting.updateDescription(request.getDescription());
+
+        return "모임 내용이 수정되었습니다.";
     }
 
     private List<UserListInfo> getUserListInfo(Meeting meeting) {

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -12,6 +12,7 @@ import com.wemo.backend.domain.meeting.service.MeetingStore;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
+import com.wemo.backend.domain.plan.dto.PlanDetailResponse;
 import com.wemo.backend.domain.plan.entity.Attendance;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
@@ -20,7 +21,6 @@ import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.domain.region.repository.DistrictRepository;
 import com.wemo.backend.domain.region.repository.ProvinceRepository;
 import com.wemo.backend.domain.region.service.RegionServiceImpl;
-import com.wemo.backend.domain.plan.dto.PlanDetailResponse;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
@@ -30,12 +30,11 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_PLAN_NOT_GRANTED;
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_GRANTED;
 
 @Slf4j
 @Service
@@ -81,7 +80,7 @@ public class PlanServiceImpl implements PlanService {
 
         // 모임장인지 검증
         Meeting meeting = meetingReader.getMeeting(meetingId);
-        if (user.getId() != meeting.getUser().getId()) throw new CustomException(ILLEGAL_PLAN_NOT_GRANTED);
+        if (user.getId() != meeting.getUser().getId()) throw new CustomException(ILLEGAL_MEETING_GRANTED);
 
         // 주소 저장
         // Step 1: 주소 파싱

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -20,9 +20,9 @@ public enum ErrorCode {
     // meeting
     ILLEGAL_MEETING_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 모임입니다."),
     ALREADY_JOINED_MEETING(HttpStatus.BAD_REQUEST, "이미 가입된 모임입니다."),
+    ILLEGAL_MEETING_GRANTED(HttpStatus.UNAUTHORIZED, "모임장만 가능한 기능입니다."),
 
     // plan
-    ILLEGAL_PLAN_NOT_GRANTED(HttpStatus.BAD_REQUEST, "모임장만 일정을 생성할 수 있습니다."),
     ILLEGAL_ADDRESS_NOT_VALID(HttpStatus.BAD_REQUEST, "주소 값이 유효하지 않습니다."),
     ILLEGAL_PLAN_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 일정입니다."),
     ALREADY_JOINED_PLAN(HttpStatus.BAD_REQUEST, "이미 참여한 일정입니다."),


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 수정 기능 구현하였습니다.
- 현재는  모임 정보 중 설명만 수정 가능합니다.
- 본인의 모임이 아닌 경우에는 권한이 없다는 메세지와 401 응답 코드가 반환됩니다.

<br/>

## 🌱 반영 브랜치
- feat/meeting-update-42
- close #42 

<br/>
