### PR TITLE
[Feat] 일정 참여 취소 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
@@ -15,4 +15,7 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
     boolean existsByUserAndPlan(User user, Plan plan);
 
     List<Attendance> findAllByPlan(Plan plan);
+
+    long countByPlan(Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
@@ -14,4 +14,8 @@ public interface AttendanceReader {
 
     void delete(Attendance attendance);
 
+    boolean existAttendance(User user, Plan plan);
+
+    int getParticipantsCount(Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
@@ -38,4 +38,24 @@ public class AttendanceReaderImpl implements AttendanceReader {
         attendanceRepository.delete(attendance);
     }
 
+    /**
+     * 일정 참여 내역 조회
+     *
+     * @param user 유저 객체
+     * @param plan 일정 객체
+     * @return 참여 내역이 있다면 true, 없다면 false
+     */
+    @Override
+    public boolean existAttendance(User user, Plan plan) {
+
+        return attendanceRepository.existsByUserAndPlan(user, plan);
+
+    }
+
+    @Override
+    public int getParticipantsCount(Plan plan) {
+
+        return (int) attendanceRepository.countByPlan(plan);
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStore.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStore.java
@@ -1,4 +1,14 @@
 package com.wemo.backend.domain.attendance.service;
 
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
+
 public interface AttendanceStore {
+
+    void storeAttendance(User user, Plan plan);
+
+    void attendPlan(User user, Plan plan);
+
+    void quitPlan(User user, Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStoreImpl.java
@@ -1,10 +1,91 @@
 package com.wemo.backend.domain.attendance.service;
 
+import com.wemo.backend.domain.attendance.entity.Attendance;
+import com.wemo.backend.domain.attendance.repository.AttendanceRepository;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.exception.CustomException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Component
 @RequiredArgsConstructor
 public class AttendanceStoreImpl implements AttendanceStore {
+
+    private final AttendanceRepository attendanceRepository;
+
+    private final AttendanceReader attendanceReader;
+
+    // 참여 내역 저장
+    @Override
+    @Transactional
+    public void storeAttendance(User user, Plan plan) {
+        Attendance attendance = Attendance.builder()
+                .user(user)
+                .plan(plan)
+                .build();
+
+        attendanceRepository.save(attendance);
+    }
+
+    // 일정 참여
+    @Override
+    @Transactional
+    public void attendPlan(User user, Plan plan) {
+
+        // 이미 참여한 일정 예외 처리
+        boolean alreadyJoined = attendanceReader.existAttendance(user, plan);
+        if (alreadyJoined) throw new CustomException(ALREADY_JOINED_PLAN);
+
+        // 모집 정원 마감 예외 처리
+        int currentParticipants = (int) attendanceRepository.countByPlan(plan);
+
+        if (currentParticipants >= plan.getCapacity()) throw new CustomException(PLAN_IS_FULLED);
+
+        // 참여 정보 저장
+        storeAttendance(user, plan);
+
+        // 인원 수 변경에 따른 일정 상태값 변경
+        updatePlanStatus(plan, currentParticipants + 1); // 기존 참여 인원에 새 참여자를 추가
+    }
+
+    // 일정 참여 취소
+    @Override
+    @Transactional
+    public void quitPlan(User user, Plan plan) {
+
+        // 주최자 필수 참여 예외 처리
+        if (plan.getUser().getEmail().equals(user.getEmail())) throw new CustomException(USER_ATTENDANCE_NECESSARY);
+
+        // 이전 참여 내역 조회 후 존재하면 삭제
+        Attendance attendance = attendanceReader.validateAttendance(user, plan);
+        attendanceRepository.delete(attendance);
+
+        // 인원 수 변경에 따른 일정 상태값 변경
+        int currentParticipants = (int) attendanceRepository.countByPlan(plan);
+        updatePlanStatus(plan, currentParticipants - 1);
+
+    }
+
+    @Transactional
+    private void updatePlanStatus(Plan plan, int participants) {
+        // 최소 인원 충족 시 개설 확정
+        if (participants >= 5) {
+            plan.open();
+        } else {
+            plan.close();
+        }
+
+        // 정원 마감 시 개설 마감
+        if (participants >= plan.getCapacity()) {
+            plan.full();
+        } else {
+            plan.hasCapacity();
+        }
+
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -202,10 +202,9 @@ public class MeetingServiceImpl implements MeetingService {
         List<Plan> planList = planReader.getPlanByMeeting(meeting);
 
         return planList.stream().map(plan -> {
-            List<Attendance> attendanceList = attendanceReader.getAttendanceList(plan);
             List<String> planImageList = imageReader.getImageList(plan.getId(), Image.EntityType.PLAN);
 
-            return PlanListInfo.fromEntity(plan, attendanceList.size(), planImageList);
+            return PlanListInfo.fromEntity(plan, attendanceReader.getParticipantsCount(plan), planImageList);
         }).collect(Collectors.toList());
     }
 

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStore.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStore.java
@@ -9,4 +9,6 @@ public interface MeetingMemberStore {
 
     void storeMemberToMeeting(User user, Meeting meeting);
 
+    void forceJoinMeeting(User user, Meeting meeting);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStoreImpl.java
@@ -17,20 +17,41 @@ public class MeetingMemberStoreImpl implements MeetingMemberStore {
 
     private final MeetingMemberRepository meetingMemberRepository;
 
+    // 모임 가입
     @Override
     @Transactional
     public void storeMemberToMeeting(User user, Meeting meeting) {
+        checkIfAlreadyJoined(user, meeting);
+        saveMeetingMember(user, meeting);
+    }
 
-        boolean alreadyJoined = meetingMemberRepository.existsByUserAndMeeting(user, meeting);
+    // 모임 미가입 시 일정 참여하는 경우
+    @Override
+    @Transactional
+    public void forceJoinMeeting(User user, Meeting meeting) {
+        if (!isAlreadyJoined(user, meeting)) {
+            saveMeetingMember(user, meeting);
+        }
+    }
 
-        if (alreadyJoined) throw new CustomException(ALREADY_JOINED_MEETING);
+    // 중복 가입 확인
+    private void checkIfAlreadyJoined(User user, Meeting meeting) {
+        if (isAlreadyJoined(user, meeting)) {
+            throw new CustomException(ALREADY_JOINED_MEETING);
+        }
+    }
 
+    // 중복 가입 여부 체크
+    private boolean isAlreadyJoined(User user, Meeting meeting) {
+        return meetingMemberRepository.existsByUserAndMeeting(user, meeting);
+    }
+
+    // 모임 회원 저장
+    private void saveMeetingMember(User user, Meeting meeting) {
         MeetingMember meetingMember = MeetingMember.builder()
                 .user(user)
                 .meeting(meeting)
                 .build();
-
         meetingMemberRepository.save(meetingMember);
     }
-
 }

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -99,4 +99,16 @@ public class PlanController {
         return ResponseEntity.ok(SuccessResponse.successWithNoData(planService.cancelPlan(userDetails.getUsername(), planId)));
     }
 
+    @Operation(summary = "일정 참여 취소", description = "일정 참여를 취소합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "일정 참여 취소되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 일정입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{planId}/attendance", method = RequestMethod.DELETE)
+    public ResponseEntity<SuccessResponse<String>> cancelAttendance(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                            @PathVariable Long planId) {
+        return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(planService.cancelAttendance(userDetails.getUsername(), planId)));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
+++ b/src/main/java/com/wemo/backend/domain/plan/entity/Plan.java
@@ -93,26 +93,34 @@ public class Plan extends Timestamped {
     @Comment("조회수")
     private int viewCount;
 
+    // 개설 확정
     public void open() {
-
         this.opened = true;
     }
 
+    // 개설 미확정
     public void close() {
+        this.opened = false;
+    }
 
+    // 조회 수 증가
+    public void updateViewCount() {
+        this.viewCount++;
+    }
+
+    // 모집 취소
+    public void cancel() {
+        this.canceled = true;
+    }
+
+    // 모집 마감 (정원 초과 또는 기간 마감)
+    public void full() {
         this.fulled = true;
     }
 
-    public void updateViewCount() {
-
-        this.viewCount++;
-
-    }
-
-    public void cancel() {
-
-        this.canceled = true;
-
+    // 재모집 (모집 정원 남은 경우)
+    public void hasCapacity() {
+        this.fulled = false;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -20,4 +20,6 @@ public interface PlanService {
 
     String cancelPlan(String email, Long planId);
 
+    String cancelAttendance(String email, Long planId);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.attendance.entity.Attendance;
 import com.wemo.backend.domain.attendance.service.AttendanceReader;
+import com.wemo.backend.domain.attendance.service.AttendanceStore;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageReader;
@@ -35,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_GRANTED;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Slf4j
 @Service
@@ -63,6 +64,8 @@ public class PlanServiceImpl implements PlanService {
     private final ImageReader imageReader;
 
     private final AttendanceReader attendanceReader;
+
+    private final AttendanceStore attendanceStore;
 
     private final MeetingMemberStore meetingMemberStore;
 
@@ -102,7 +105,7 @@ public class PlanServiceImpl implements PlanService {
         Plan plan = planStore.storePlan(request, district, user, meeting);
 
         // 주최자는 일정에 자동으로 참여
-        planStore.joinPlan(user, plan);
+        attendanceStore.attendPlan(user, plan);
 
         // 이미지 저장 (선택)
         if (!request.getFileUrls().isEmpty()) {
@@ -128,10 +131,10 @@ public class PlanServiceImpl implements PlanService {
         User user = userReader.getUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
-        planStore.joinPlan(user, plan);
+        attendanceStore.attendPlan(user, plan);
 
         // 일정 참여 시 모임에도 자동으로 가입
-        meetingMemberStore.storeMemberToMeeting(user, plan.getMeeting());
+        meetingMemberStore.forceJoinMeeting(user, plan.getMeeting());
 
         return "일정 참여 신청 완료되었습니다.";
     }
@@ -220,6 +223,27 @@ public class PlanServiceImpl implements PlanService {
         plan.cancel();
 
         return "일정이 정상적으로 취소되었습니다.";
+    }
+
+    /**
+     * 일정 참여 취소
+     *
+     * @param email 이메일
+     * @param planId 일정 id
+     * @return 성공 메세지
+     */
+    @Override
+    public String cancelAttendance(String email, Long planId) {
+
+        // 유저 검증 및 조회
+        User user = userReader.getUserByEmail(email);
+
+        // 일정 검증 및 조회
+        Plan plan = planReader.getPlan(planId);
+
+        attendanceStore.quitPlan(user, plan);
+
+        return "일정 참여가 취소되었습니다.";
     }
 
     private List<UserListInfo> getUserListFromAttendance(Plan plan) {

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
@@ -10,6 +10,4 @@ public interface PlanStore {
 
     Plan storePlan(PlanCreateRequest request, District district, User user, Meeting meeting);
 
-    void joinPlan(User user, Plan plan);
-
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -1,6 +1,8 @@
 package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.attendance.entity.Attendance;
+import com.wemo.backend.domain.attendance.service.AttendanceReader;
+import com.wemo.backend.domain.attendance.service.AttendanceStore;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.entity.Plan;
@@ -26,7 +28,9 @@ public class PlanStoreImpl implements PlanStore{
 
     private final PlanRepository planRepository;
 
-    private final AttendanceRepository attendanceRepository;
+    private final AttendanceReader attendanceReader;
+
+    private final AttendanceStore attendanceStore;
 
     @Override
     @Transactional
@@ -52,39 +56,6 @@ public class PlanStoreImpl implements PlanStore{
         planRepository.save(plan);
 
         return plan;
-    }
-
-    @Override
-    @Transactional
-    public void joinPlan(User user, Plan plan) {
-
-        // 이미 참여한 일정 예외 처리
-        boolean alreadyJoined = attendanceRepository.existsByUserAndPlan(user, plan);
-        if (alreadyJoined) throw new CustomException(ALREADY_JOINED_PLAN);
-
-        // 모집 정원 마감 예외 처리
-        List<Attendance> allByPlan = attendanceRepository.findAllByPlan(plan);
-        if (allByPlan.size() >= plan.getCapacity()) throw new CustomException(PLAN_IS_FULLED);
-
-        Attendance attendance = Attendance.builder()
-                .user(user)
-                .plan(plan)
-                .build();
-
-        attendanceRepository.save(attendance);
-
-        // 인원 수 변경에 따른 일정 상태값 변경
-        updatePlanStatus(plan, allByPlan.size() + 1); // 기존 참여 인원에 새 참여자를 추가
-    }
-
-    @Transactional
-    private void updatePlanStatus(Plan plan, int participants) {
-        // 최소 인원 충족 시 개설 확정
-        if (participants >= 5) plan.open();
-
-        // 정원 마감 시 개설 마감
-        if (participants >= plan.getCapacity()) plan.close();
-
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -141,7 +141,8 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         queryFactory.select(image.fileUrl)
                                                 .from(image)
                                                 .where(image.entityId.eq(plan.id),
-                                                        image.entityType.eq(Image.EntityType.PLAN)),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
                                         "planImagePath"
                                 ),
                                 plan.dateTime,
@@ -225,7 +226,8 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         queryFactory.select(image.fileUrl)
                                                 .from(image)
                                                 .where(image.entityId.eq(review.id),
-                                                        image.entityType.eq(Image.EntityType.REVIEW)),
+                                                        image.entityType.eq(Image.EntityType.REVIEW),
+                                                        image.main.eq(true)),
                                         "reviewImagePath"
                                 ),
                                 review.createdAt,
@@ -278,7 +280,8 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         queryFactory.select(image.fileUrl)
                                                 .from(image)
                                                 .where(image.entityId.eq(plan.id),
-                                                        image.entityType.eq(Image.EntityType.PLAN)),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
                                         "planImagePath"
                                 ),
                                 plan.capacity,

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -136,6 +136,7 @@ public class UserServiceImpl implements UserService {
      * @return 유저가 참여한 일정 목록
      */
     @Override
+    @Transactional
     public UserPlanPagingResponse getMyPlanList(String email, Pageable pageable) {
 
         return new UserPlanPagingResponse(userRepository.getUserPlanList(email, pageable));
@@ -162,6 +163,7 @@ public class UserServiceImpl implements UserService {
      * @return 후기 작성 가능한 일정 목록
      */
     @Override
+    @Transactional
     public UserPlanPagingResponse getPlanListReviewAvailable(String email, Pageable pageable) {
 
         return new UserPlanPagingResponse(userRepository.getUserPlanListReviewAvailable(email, pageable));

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     PLAN_ATTENDANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 일정에 참여 기록이 없습니다."),
     ALREADY_LIKED_PLAN(HttpStatus.BAD_REQUEST, "이미 좋아요한 일정입니다."),
     LIKE_NOT_FOUND(HttpStatus.NOT_FOUND, "좋아요를 누르지 않은 일정입니다."),
+    USER_ATTENDANCE_NECESSARY(HttpStatus.BAD_REQUEST, "주최자는 필수 참여입니다."),
 
     // review
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST ,"이미 후기를 등록한 일정입니다."),


### PR DESCRIPTION
## 📌 작업 내용
- **일정 참여 취소 기능 구현**  
  - 기존 참여 내역이 없는 경우 예외 반환 처리
  - 참여 인원 수 변경에 따른 일정 상태값 자동 갱신
- **일정 참여 시 모임 가입 처리 개선**  
  - 모임 자동 가입과 수동 가입 처리 메서드를 분리
  - 중복 가입 시 예외 처리 추가
- **마이페이지 관련 수정**  
  - 일정 및 후기 목록 조회 시 대표 이미지 조건 추가하여 오류 해결

<br/>

## 🌱 반영 브랜치
- feat/plan-attendanceCancel-45 -> 45  
- close #45
