### PR TITLE
[Feat] 좋아요한 일정 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/like/entity/Likes.java
+++ b/src/main/java/com/wemo/backend/domain/like/entity/Likes.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.like.entity;
 
+import com.querydsl.core.annotations.QueryEntity;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.entity.Timestamped;
@@ -14,7 +15,8 @@ import org.hibernate.annotations.Comment;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Like extends Timestamped {
+@QueryEntity
+public class Likes extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
@@ -1,15 +1,15 @@
 package com.wemo.backend.domain.like.repository;
 
-import com.wemo.backend.domain.like.entity.Like;
+import com.wemo.backend.domain.like.entity.Likes;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LikeRepository extends JpaRepository<Like, Long> {
+public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     boolean existsByUserAndPlan(User user, Plan plan);
 
-    Like findByUserAndPlan(User user, Plan plan);
+    Likes findByUserAndPlan(User user, Plan plan);
 
     int countByPlan(Plan plan);
 

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeStoreImpl.java
@@ -1,6 +1,6 @@
 package com.wemo.backend.domain.like.service;
 
-import com.wemo.backend.domain.like.entity.Like;
+import com.wemo.backend.domain.like.entity.Likes;
 import com.wemo.backend.domain.like.repository.LikeRepository;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
@@ -18,7 +18,7 @@ public class LikeStoreImpl implements LikeStore {
     @Transactional
     public void storeLike(User user, Plan plan) {
 
-        Like like = Like.builder()
+        Likes like = Likes.builder()
                 .user(user)
                 .plan(plan)
                 .build();
@@ -29,7 +29,7 @@ public class LikeStoreImpl implements LikeStore {
     @Override
     public void deleteLike(User user, Plan plan) {
 
-        Like like = likeRepository.findByUserAndPlan(user, plan);
+        Likes like = likeRepository.findByUserAndPlan(user, plan);
 
         likeRepository.delete(like);
     }

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -7,6 +7,7 @@ import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.service.PlanService;
 import com.wemo.backend.domain.plan.dto.PlanDetailResponse;
+import com.wemo.backend.domain.user.dto.UserPlanPagingResponse;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -15,6 +16,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -109,6 +113,28 @@ public class PlanController {
     public ResponseEntity<SuccessResponse<String>> cancelAttendance(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                             @PathVariable Long planId) {
         return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(planService.cancelAttendance(userDetails.getUsername(), planId)));
+    }
+
+    @Operation(summary = "좋아요한 일정 목록 조회", description = "유저가 좋아요한 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "좋아요한 일정의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/like", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getLikedPlanList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                 @RequestParam(defaultValue = "1") int page,
+                                                                                 @RequestParam(defaultValue = "10") int size,
+                                                                                 @RequestParam(required = false) String query,
+                                                                                 @RequestParam(required = false) String province,
+                                                                                 @RequestParam(required = false) String district,
+                                                                                 @RequestParam(required = false) String startDate,
+                                                                                 @RequestParam(required = false) String endDate,
+                                                                                 @RequestParam(required = false) Long categoryId,
+                                                                                 @RequestParam(required = false) String sort) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(planService.getLikedPlanList(userDetails.getUsername(), pageable, query, province, district, startDate, endDate, categoryId, sort)));
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -3,11 +3,12 @@ package com.wemo.backend.domain.plan.repository;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.querydsl.PlanCursorQueryDsl;
+import com.wemo.backend.domain.plan.repository.querydsl.PlanQueryDsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface PlanRepository extends JpaRepository<Plan, Long>, PlanCursorQueryDsl {
+public interface PlanRepository extends JpaRepository<Plan, Long>, PlanCursorQueryDsl, PlanQueryDsl {
 
     List<Plan> findAllByMeeting(Meeting meeting);
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -19,7 +19,7 @@ import java.util.Optional;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
-import static com.wemo.backend.domain.like.entity.QLike.like;
+import static com.wemo.backend.domain.like.entity.QLikes.likes;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
 import static com.wemo.backend.domain.region.entity.QDistrict.district;
@@ -50,7 +50,6 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         return getPlanList(null, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
     }
 
-
     private PlanCursorPagingResponse getPlanList(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
 
         updateIsFulledStatus();
@@ -70,7 +69,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         }
 
         List<PlanListResponse> planListResponses = queryFactory
-                .select(buildGatheringListProjection(email))
+                .select(buildPlanListProjection(email))
                 .from(plan)
                 .leftJoin(plan.user, user)
                 .where(listConditions)
@@ -91,7 +90,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         return new PlanCursorPagingResponse(planListResponses, (int) planCount);
     }
 
-    private ConstructorExpression<PlanListResponse> buildGatheringListProjection(String email) {
+    public ConstructorExpression<PlanListResponse> buildPlanListProjection(String email) {
 
         return Projections.constructor(
                 PlanListResponse.class,
@@ -149,10 +148,10 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                         "participants"
                 ),
                 Expressions.as(
-                        queryFactory.select(like.count())
-                                .from(like)
-                                .where(like.plan.id.eq(plan.id)),
-                        "likeCount"
+                        queryFactory.select(likes.count())
+                                .from(likes)
+                                .where(likes.plan.id.eq(plan.id)),
+                        "likesCount"
                 ),
                 plan.viewCount,
                 plan.createdAt,
@@ -160,21 +159,26 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                 plan.opened,
                 plan.fulled,
                 Expressions.as(
-                        queryFactory.select(like.count())
-                                .from(like)
+                        queryFactory.select(likes.count())
+                                .from(likes)
                                 .where(
-                                        like.plan.id.eq(plan.id)
+                                        likes.plan.id.eq(plan.id)
                                                 .and(
                                                         email != null
-                                                                ? like.user.email.eq(email)
-                                                                : like.user.email.isNull()
+                                                                ? likes.user.email.eq(email)
+                                                                : likes.user.email.isNull()
                                                 )
                                 ).gt(0L),
-                        "isLiked")
+                        "islikesd")
         );
     }
 
     private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
+
+        return getBooleanExpression(query, province, district, startDate, endDate, categoryId);
+    }
+
+    static BooleanExpression getBooleanExpression(String query, String province, String district, String startDate, String endDate, Long categoryId) {
 
         BooleanExpression condition = plan.canceled.eq(false);
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDsl.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.plan.repository.querydsl;
+
+import com.wemo.backend.domain.plan.dto.PlanListResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PlanQueryDsl {
+
+    Page<PlanListResponse> getLikedPlanList(String email, Pageable pageable, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
@@ -1,0 +1,179 @@
+package com.wemo.backend.domain.plan.repository.querydsl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.plan.dto.PlanListResponse;
+import com.wemo.backend.domain.region.entity.QDistrict;
+import com.wemo.backend.domain.region.entity.QProvince;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
+import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.like.entity.QLikes.likes;
+import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
+import static com.wemo.backend.domain.plan.entity.QPlan.plan;
+import static com.wemo.backend.domain.plan.repository.querydsl.PlanCursorQueryDslImpl.getBooleanExpression;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+@Slf4j
+public class PlanQueryDslImpl implements PlanQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public PlanQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    private static final String DEFAULT_SORT_FIELD = "createdAt";
+
+    @Override
+    public Page<PlanListResponse> getLikedPlanList(String email, Pageable pageable, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        updateIsFulledStatus();
+
+        log.info("{}가 좋아요한 일정 목록 조회 요청", email);
+
+        String sortField = (sort == null) ? DEFAULT_SORT_FIELD : sort;
+
+        BooleanBuilder baseConditions = new BooleanBuilder()
+                .and(buildFilterConditions(query, province, district, startDate, endDate, categoryId));
+
+        JPAQuery<PlanListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                PlanListResponse.class,
+                                user.nickname.as("nickname"),
+                                user.profileImagePath.as("profileImage"),
+                                plan.id.as("planId"),
+                                plan.planName,
+                                Expressions.as(
+                                        queryFactory.select(meeting.category.categoryName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "category"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.id)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingId"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.meetingName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingName"
+                                ),
+                                plan.address,
+                                Expressions.as(
+                                        queryFactory.select(QProvince.province.provinceName)
+                                                .from(QProvince.province)
+                                                .where(plan.district.province.id.eq(QProvince.province.id)),
+                                        "province"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(QDistrict.district.districtName)
+                                                .from(QDistrict.district)
+                                                .where(plan.district.id.eq(QDistrict.district.id)),
+                                        "district"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
+                                        "planImagePath"
+                                ),
+                                plan.dateTime,
+                                plan.registrationEnd,
+                                plan.capacity,
+                                Expressions.as(
+                                        queryFactory.select(attendance.count())
+                                                .from(attendance)
+                                                .where(attendance.plan.id.eq(plan.id)
+                                                        .and(attendance.deletedAt.isNull())),
+                                        "participants"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(likes.plan.id.eq(plan.id)),
+                                        "likeCount"
+                                ),
+                                plan.viewCount,
+                                plan.createdAt,
+                                plan.updatedAt,
+                                plan.opened,
+                                plan.fulled,
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(
+                                                        likes.plan.id.eq(plan.id)
+                                                                .and(likes.user.email.eq(email))
+                                                ).gt(0L),
+                                        "isLiked")
+                        )
+                )
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .leftJoin(likes).on(likes.plan.id.eq(plan.id))
+                .where(baseConditions)
+                .where(likes.user.email.eq(email)) // 유저가 좋아요한 일정
+                .where(plan.canceled.eq(false))
+                .orderBy(sortField.equals("closeDate") ? plan.registrationEnd.asc() : plan.createdAt.desc());
+
+        List<PlanListResponse> planListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(plan.count())
+                        .from(plan)
+                        .leftJoin(plan.user, user)
+                        .leftJoin(likes).on(likes.plan.id.eq(plan.id))
+                        .where(baseConditions)
+                        .where(likes.user.email.eq(email)) // 유저가 좋아요한 일정
+                        .where(plan.canceled.eq(false))
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(planListResponses, pageable, total);
+
+    }
+
+    private void updateIsFulledStatus() {
+
+        long updatedCount = queryFactory.update(plan)
+                .set(plan.fulled, true)
+                .where(plan.registrationEnd.before(LocalDateTime.now())
+                        .and(plan.fulled.eq(false)))
+                .execute();
+
+        log.info("일정의 모집 마감 상태가 {} 번 업데이트되었습니다.", updatedCount);
+
+    }
+
+    private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
+
+        return getBooleanExpression(query, province, district, startDate, endDate, categoryId);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -5,6 +5,8 @@ import com.wemo.backend.domain.plan.dto.PlanCreateRequest;
 import com.wemo.backend.domain.plan.dto.PlanCreateResponse;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.dto.PlanDetailResponse;
+import com.wemo.backend.domain.user.dto.UserPlanPagingResponse;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -21,5 +23,7 @@ public interface PlanService {
     String cancelPlan(String email, Long planId);
 
     String cancelAttendance(String email, Long planId);
+
+    UserPlanPagingResponse getLikedPlanList(String email, Pageable pageable, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -24,12 +24,14 @@ import com.wemo.backend.domain.region.repository.DistrictRepository;
 import com.wemo.backend.domain.region.repository.ProvinceRepository;
 import com.wemo.backend.domain.region.service.RegionServiceImpl;
 import com.wemo.backend.domain.user.dto.UserListInfo;
+import com.wemo.backend.domain.user.dto.UserPlanPagingResponse;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
 import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -244,6 +246,29 @@ public class PlanServiceImpl implements PlanService {
         attendanceStore.quitPlan(user, plan);
 
         return "일정 참여가 취소되었습니다.";
+    }
+
+    /**
+     * 좋아요한 일정 목록 조회
+     *
+     * @param email       이메일
+     * @param pageable    페이징 처리 데이터
+     * @param query       검색어
+     * @param province    시/도 데이터
+     * @param district    군/구 데이터
+     * @param startDate   시작 날짜
+     * @param endDate     끝 날짜
+     * @param categoryId  카테고리 id
+     * @param sort        정렬 기준
+     * @return 조건에 해당하는 좋아요한 일정 목록
+     */
+    @Override
+    @Transactional
+    public UserPlanPagingResponse getLikedPlanList(String email, Pageable pageable, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+
+        // 유저 검증
+        userReader.getUserByEmail(email);
+        return new UserPlanPagingResponse(planRepository.getLikedPlanList(email, pageable, query, province, district, startDate, endDate,categoryId, sort));
     }
 
     private List<UserListInfo> getUserListFromAttendance(Plan plan) {

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.category.entity.QCategory.category;
 import static com.wemo.backend.domain.image.entity.QImage.image;
-import static com.wemo.backend.domain.like.entity.QLike.like;
+import static com.wemo.backend.domain.like.entity.QLikes.likes;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.meetingMember.entity.QMeetingMember.meetingMember;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
@@ -156,10 +156,10 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         "participants"
                                 ),
                                 Expressions.as(
-                                        queryFactory.select(like.count())
-                                                .from(like)
-                                                .where(like.plan.id.eq(plan.id)),
-                                        "likeCount"
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(likes.plan.id.eq(plan.id)),
+                                        "likesCount"
                                 ),
                                 plan.viewCount,
                                 plan.createdAt,
@@ -168,17 +168,17 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 plan.canceled,
                                 plan.fulled,
                                 Expressions.as(
-                                        queryFactory.select(like.count())
-                                                .from(like)
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
                                                 .where(
-                                                        like.plan.id.eq(plan.id)
+                                                        likes.plan.id.eq(plan.id)
                                                                 .and(
                                                                         email != null
-                                                                                ? like.user.email.eq(email)
-                                                                                : like.user.email.isNull()
+                                                                                ? likes.user.email.eq(email)
+                                                                                : likes.user.email.isNull()
                                                                 )
                                                 ).gt(0L),
-                                        "isLiked")
+                                        "islikesd")
                         )
                 )
                 .from(plan)
@@ -186,7 +186,6 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
                 .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
                 .orderBy(plan.createdAt.desc());
-
 
         // 페이징 처리
         List<UserPlanListResponse> planListResponses = queryBuilder


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 유저가 좋아요한 일정 목록을 조회하는 기능을 구현하였습니다.
- 페이지 기반 페이징 처리된 목록으로 반환합니다.
- 일정명으로 검색할 수 있으며, 지역, 날짜, 카테고리를 기준으로 필터링할 수 있습니다.
- 취소된 일정은 목록에 포함되지 않도록 구현하였습니다.
- `Like` 클래스명을 `Likes`로 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/plan-likedList-46
- close #46

<br/>

## 🔥 트러블 슈팅 (선택)
- `QueryDsl`에서 `like`라는 예약어를 사용하여 `QLike` 클래스의 변수가 `like1`로 생성되어 데이터를 읽어오지 못하는 오류가 발생했습니다.
- 이를 해결하기 위해 클래스명을 `Likes`로 변경하고, 재빌드하여 `Q` 클래스를 다시 생성한 후 정상적으로 동작하도록 수정하였습니다.
