### PR TITLE
[Feat] 후기 수정 기능 구현 

### DIFF
--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStore.java
@@ -11,4 +11,6 @@ public interface ImageStore {
 
     List<String> storeImageList(User user, Long entityId, List<String> fileUrls, Image.EntityType entityType);
 
+    void updateImage(User user, Long entityId, List<String> fileUrls, Image.EntityType entityType);
+
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
@@ -14,6 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ImageStoreImpl implements ImageStore {
 
+    private final ImageReader imageReader;
     private final ImageRepository imageRepository;
 
     @Override
@@ -35,6 +36,7 @@ public class ImageStoreImpl implements ImageStore {
     @Override
     @Transactional
     public List<String> storeImageList(User user, Long entityId, List<String> fileUrls, Image.EntityType entityType) {
+
         List<String> imageList = new ArrayList<>();
 
         for (int i = 0; i < fileUrls.size(); i++) {
@@ -61,6 +63,16 @@ public class ImageStoreImpl implements ImageStore {
         }
 
         return imageList;
+    }
+
+    @Override
+    public void updateImage(User user, Long entityId, List<String> fileUrls, Image.EntityType entityType) {
+        // 기존 이미지 삭제
+        List<Image> allByEntityIdAndEntityType = imageRepository.findAllByEntityIdAndEntityType(entityId, entityType);
+        imageRepository.deleteAll(allByEntityIdAndEntityType);
+
+        // 다시 저장
+        storeImageList(user, entityId, fileUrls, entityType);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
+++ b/src/main/java/com/wemo/backend/domain/review/controller/ReviewController.java
@@ -61,4 +61,19 @@ public class ReviewController {
         return ResponseEntity.ok(SuccessResponse.successWithData(reviewService.getReviewList(pageable, province, district, startDate, endDate, categoryId, sort)));
     }
 
+    @Operation(summary = "후기 수정", description = "후기를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "후기가 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 후기입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{reviewId}", method = RequestMethod.PUT)
+    public ResponseEntity<SuccessResponse<ReviewCreateResponse>> updateReview(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                              @PathVariable Long reviewId,
+                                                                              @Valid @RequestBody ReviewCreateRequest request) {
+        return ResponseEntity.ok(SuccessResponse.successWithData(reviewService.updateReview(userDetails.getUsername(), reviewId, request)));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/entity/Review.java
+++ b/src/main/java/com/wemo/backend/domain/review/entity/Review.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.review.entity;
 
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.entity.Timestamped;
 import jakarta.persistence.*;
@@ -47,5 +48,14 @@ public class Review extends Timestamped {
     @JoinColumn(name = "plan_id", nullable = false)
     @Comment("일정 id")
     private Plan plan;
+
+    public Review update(ReviewCreateRequest request) {
+
+        // 다른 필드만 업데이트, plan 필드는 유지
+        this.score = request.getScore();
+        this.comment = request.getComment();
+        return this;
+
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.review.service;
 
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.user.entity.User;
 
 import java.util.List;
 
@@ -10,5 +11,9 @@ public interface ReviewReader {
     List<Review> getReviewByPlan(Plan plan);
 
     void delete(Review review);
+
+    Review getReview(Long reviewId);
+
+    void validateReview(User user, Review review);
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
@@ -3,10 +3,15 @@ package com.wemo.backend.domain.review.service;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.review.entity.Review;
 import com.wemo.backend.domain.review.repository.ReviewRepository;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_REVIEW_GRANTED;
+import static com.wemo.backend.global.exception.ErrorCode.REVIEW_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
@@ -24,6 +29,20 @@ public class ReviewReaderImpl implements ReviewReader {
     public void delete(Review review) {
 
         reviewRepository.delete(review);
+    }
+
+    @Override
+    public Review getReview(Long reviewId) {
+
+        return reviewRepository.findById(reviewId).orElseThrow(
+                () -> new CustomException(REVIEW_NOT_FOUND)
+        );
+    }
+
+    @Override
+    public void validateReview(User user, Review review) {
+
+        if (!user.getEmail().equals(review.getUser().getEmail())) throw new CustomException(ILLEGAL_REVIEW_GRANTED);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewService.java
@@ -1,6 +1,5 @@
 package com.wemo.backend.domain.review.service;
 
-import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.review.dto.ReviewCreateRequest;
 import com.wemo.backend.domain.review.dto.ReviewCreateResponse;
 import com.wemo.backend.domain.review.dto.ReviewPagingResponse;
@@ -13,5 +12,7 @@ public interface ReviewService {
     ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request);
 
     ReviewPagingResponse getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+
+    ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest request);
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -41,6 +41,8 @@ public class ReviewServiceImpl implements ReviewService {
 
     private final AttendanceReader attendanceReader;
 
+    private final ReviewReader reviewReader;
+
     /**
      * 후기 등록
      *
@@ -77,7 +79,7 @@ public class ReviewServiceImpl implements ReviewService {
         Review review = reviewStore.storeReview(request, user, plan);
 
         // 이미지 저장 (선택)
-        if (!request.getFileUrls().isEmpty()) {
+        if (request.getFileUrls() != null || !request.getFileUrls().isEmpty()) {
             List<String> imageList = imageStore.storeImageList(user, review.getId(), request.getFileUrls(), Image.EntityType.REVIEW);
             return ReviewCreateResponse.fromEntityWithImage(plan, review, imageList);
         }
@@ -101,6 +103,34 @@ public class ReviewServiceImpl implements ReviewService {
     public ReviewPagingResponse getReviewList(Pageable pageable, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
 
         return new ReviewPagingResponse(reviewRepository.getReviewList(pageable, province, district, startDate, endDate, categoryId, sort));
+    }
+
+    /**
+     * 후기 수정
+     *
+     * @param email 이메일
+     * @param reviewId 후기 id
+     * @param request 후기 수정 데이터 (평점, 내용, 이미지)
+     * @return 수정된 후기 정보
+     */
+    @Override
+    @Transactional
+    public ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest request) {
+
+        User user = userReader.getUserByEmail(email);
+        Review review = reviewReader.getReview(reviewId);
+        // 본인 후기인지 확인
+        reviewReader.validateReview(user, review);
+
+        Review updatedReview = review.update(request);
+        Plan plan = updatedReview.getPlan();
+
+        // 이미지 수정 (선택)
+        if (request.getFileUrls() != null || !request.getFileUrls().isEmpty()) {
+            imageStore.updateImage(user, reviewId, request.getFileUrls(), Image.EntityType.REVIEW);
+            return ReviewCreateResponse.fromEntityWithImage(plan, updatedReview, request.getFileUrls());
+        }
+        return ReviewCreateResponse.fromEntity(plan, updatedReview);
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -35,6 +35,8 @@ public enum ErrorCode {
     // review
     REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST ,"이미 후기를 등록한 일정입니다."),
     REVIEW_CREATION_BEFORE_PLAN_END(HttpStatus.BAD_REQUEST,"일정이 완료되지 않아 후기를 작성할 수 없습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 후기입니다."),
+    ILLEGAL_REVIEW_GRANTED(HttpStatus.UNAUTHORIZED, "본인이 작성한 후기만 수정/삭제가 가능합니다."),
 
     // image
     ILLEGAL_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "이미지는 한 번에 최대 10개까지 요청 가능합니다.");


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 후기 수정 기능 구현하였습니다.
- 본인이 작성한 후기만 수정 가능하도록 구현하였으며, 본인의 후기가 아닌 경우 `401`을 반환합니다.
- 평점, 내용, 이미지 모두 수정 가능하도록 처리하였습니다.
- 이미지 수정의 경우 기존 이미지를 전체 삭제한 뒤, 요청으로 들어온 이미지를 새로 저장하는 방식으로 구현하였습니다.
- 이미지가 빈 배열로 요청될 경우, 해당 후기의 이미지가 모두 삭제되어 빈 배열로 반환됩니다.

<br/>

## 🌱 반영 브랜치
- feat/review-update-47 -> dev
- close #47 

<br/>

## 🔥 트러블 슈팅 (선택)
- 후기 수정 시 `Review.builder().build();`를 사용하여 새로운 객체를 생성하면서, `plan` 필드가 `null`로 설정되는 문제가 발생했습니다.
- 이로 인해 `plan.getId()` 호출 시 `NullPointerException` 오류가 발생하였습니다.
- 문제 원인을 파악한 뒤, `builder()`를 통한 객체 생성 대신 `this` 키워드를 사용해 기존 객체의 필드를 업데이트하도록 수정하였습니다.
- 해당 변경을 통해 `plan` 참조가 유지되며, `NullPointerException` 문제가 해결되었습니다.

<br/>

## ✅ 추가 구현 및 개선
- **데이터 정합성 유지**: 엔티티 객체를 업데이트할 때, 새로운 객체를 생성하지 않고 기존 객체를 수정하는 방식으로 수정하여 영속성 컨텍스트와의 일관성을 유지하였습니다.
- **테스트 코드 계획**: 본인의 후기만 수정 가능하도록 하는 로직과 이미지 수정 시 기존 이미지 삭제 및 새로 저장되는 로직에 대해 테스트 코드를 작성할 계획입니다.
- **예외 처리 강화**: 본인의 후기가 아닌 경우, 명확한 예외 메시지를 반환하도록 `validateReview()` 메서드를 개선하였습니다.
- **코드 최적화**: 후기 수정 시 필요 없는 객체 재생성을 방지하고, 메모리 사용량을 줄이는 방향으로 최적화하였습니다.
