### PR TITLE
[Feat] 지역 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -159,7 +159,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/api/auths/signup") ||
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
-                requestURI.startsWith("/v3/api-docs");
+                requestURI.startsWith("/v3/api-docs") ||
+                requestURI.startsWith("/api/regions");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wemo/backend/domain/region/controller/RegionController.java
@@ -1,14 +1,17 @@
 package com.wemo.backend.domain.region.controller;
 
+import com.wemo.backend.domain.region.dto.DistrictListResponse;
 import com.wemo.backend.domain.region.dto.ProvinceListResponse;
 import com.wemo.backend.domain.region.service.RegionService;
 import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Regions")
 @RestController
@@ -18,8 +21,22 @@ public class RegionController {
 
     private final RegionService regionService;
 
+    @Operation(summary = "전체 시/도 데이터 목록 조회", description = "전체 시/도 데이터 목록입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 시/도 데이터 목록 입니다.")
+    })
     @RequestMapping(value = "/province", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<ProvinceListResponse>> getProvinceList() {
         return ResponseEntity.ok(SuccessResponse.successWithData(regionService.getProvinceList()));
     }
+
+    @Operation(summary = "전체 군/구 데이터 목록 조회", description = "전체 군/구 데이터 목록입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 군/구 데이터 목록 입니다.")
+    })
+    @RequestMapping(value = "/district", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<DistrictListResponse>> getDistrictList(@RequestParam Long provinceId) {
+        return ResponseEntity.ok(SuccessResponse.successWithData(regionService.getDistrictList(provinceId)));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/controller/RegionController.java
+++ b/src/main/java/com/wemo/backend/domain/region/controller/RegionController.java
@@ -1,4 +1,25 @@
 package com.wemo.backend.domain.region.controller;
 
+import com.wemo.backend.domain.region.dto.ProvinceListResponse;
+import com.wemo.backend.domain.region.service.RegionService;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Regions")
+@RestController
+@RequestMapping("/api/regions")
+@RequiredArgsConstructor
 public class RegionController {
+
+    private final RegionService regionService;
+
+    @RequestMapping(value = "/province", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<ProvinceListResponse>> getProvinceList() {
+        return ResponseEntity.ok(SuccessResponse.successWithData(regionService.getProvinceList()));
+    }
 }

--- a/src/main/java/com/wemo/backend/domain/region/dto/DistrictListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/region/dto/DistrictListInfo.java
@@ -1,0 +1,18 @@
+package com.wemo.backend.domain.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class DistrictListInfo {
+
+    private Long provinceId;
+
+    private Long districtId;
+
+    private String name;
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/dto/DistrictListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/region/dto/DistrictListResponse.java
@@ -1,0 +1,13 @@
+package com.wemo.backend.domain.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class DistrictListResponse {
+
+    List<DistrictListInfo> districtList;
+}

--- a/src/main/java/com/wemo/backend/domain/region/dto/ProvinceListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/region/dto/ProvinceListInfo.java
@@ -1,0 +1,16 @@
+package com.wemo.backend.domain.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProvinceListInfo {
+
+    private Long provinceId;
+
+    private String name;
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/dto/ProvinceListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/region/dto/ProvinceListResponse.java
@@ -1,0 +1,13 @@
+package com.wemo.backend.domain.region.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ProvinceListResponse {
+
+    private List<ProvinceListInfo> provinceList;
+}

--- a/src/main/java/com/wemo/backend/domain/region/repository/DistrictRepository.java
+++ b/src/main/java/com/wemo/backend/domain/region/repository/DistrictRepository.java
@@ -4,10 +4,13 @@ import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface DistrictRepository extends JpaRepository<District, Long> {
 
     Optional<District> findByDistrictNameAndProvince(String districtName, Province province);
+
+    List<District> findAllByProvince(Province province);
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionReader.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionReader.java
@@ -1,0 +1,11 @@
+package com.wemo.backend.domain.region.service;
+
+import com.wemo.backend.domain.region.entity.Province;
+
+import java.util.List;
+
+public interface RegionReader {
+
+    List<Province> getAllProvinceList();
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionReader.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionReader.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 
 import java.util.List;
@@ -7,5 +8,7 @@ import java.util.List;
 public interface RegionReader {
 
     List<Province> getAllProvinceList();
+
+    List<District> getAllDistrictList(Long provinceId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
@@ -1,13 +1,18 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.dto.ProvinceListResponse;
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.domain.region.repository.DistrictRepository;
 import com.wemo.backend.domain.region.repository.ProvinceRepository;
+import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+
+import static com.wemo.backend.global.exception.ErrorCode.PROVINCE_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
@@ -21,6 +26,16 @@ public class RegionReaderImpl implements RegionReader {
     public List<Province> getAllProvinceList() {
 
         return provinceRepository.findAll(Sort.by(Sort.Order.asc("id")));
+    }
+
+    @Override
+    public List<District> getAllDistrictList(Long provinceId) {
+
+        Province province = provinceRepository.findById(provinceId).orElseThrow(
+                () -> new CustomException(PROVINCE_NOT_FOUND)
+        );
+
+        return districtRepository.findAllByProvince(province);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
@@ -1,0 +1,26 @@
+package com.wemo.backend.domain.region.service;
+
+import com.wemo.backend.domain.region.entity.Province;
+import com.wemo.backend.domain.region.repository.DistrictRepository;
+import com.wemo.backend.domain.region.repository.ProvinceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class RegionReaderImpl implements RegionReader {
+
+    private final ProvinceRepository provinceRepository;
+
+    private final DistrictRepository districtRepository;
+
+    @Override
+    public List<Province> getAllProvinceList() {
+
+        return provinceRepository.findAll(Sort.by(Sort.Order.asc("id")));
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionService.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionService.java
@@ -1,9 +1,12 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.dto.DistrictListResponse;
 import com.wemo.backend.domain.region.dto.ProvinceListResponse;
 
 public interface RegionService {
 
     ProvinceListResponse getProvinceList();
+
+    DistrictListResponse getDistrictList(Long provinceId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionService.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionService.java
@@ -1,4 +1,9 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.dto.ProvinceListResponse;
+
 public interface RegionService {
+
+    ProvinceListResponse getProvinceList();
+
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
@@ -1,7 +1,10 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.dto.DistrictListInfo;
+import com.wemo.backend.domain.region.dto.DistrictListResponse;
 import com.wemo.backend.domain.region.dto.ProvinceListInfo;
 import com.wemo.backend.domain.region.dto.ProvinceListResponse;
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
@@ -48,10 +51,26 @@ public class RegionServiceImpl implements RegionService {
                         .provinceId(province.getId())
                         .name(province.getProvinceName())
                         .build())
-                .collect(Collectors.toList());
+                .toList();
 
         // 변환된 리스트로 ProvinceListResponse 생성
         return new ProvinceListResponse(provinceListInfos);
     }
+
+    @Override
+    public DistrictListResponse getDistrictList(Long provinceId) {
+
+        // District 객체를 DistrictListInfo로 변환하여 리스트로 수집
+        List<DistrictListInfo> districtListInfos = regionReader.getAllDistrictList(provinceId).stream()
+                .map(district -> DistrictListInfo.builder()
+                        .provinceId(provinceId)
+                        .districtId(district.getId())
+                        .name(district.getDistrictName())
+                        .build())
+                .toList();
+
+        return new DistrictListResponse(districtListInfos);
+    }
+
 
 }

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
@@ -1,15 +1,25 @@
 package com.wemo.backend.domain.region.service;
 
+import com.wemo.backend.domain.region.dto.ProvinceListInfo;
+import com.wemo.backend.domain.region.dto.ProvinceListResponse;
+import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static com.wemo.backend.global.exception.ErrorCode.*;
 
 @Service
-public class RegionServiceImpl {
+@RequiredArgsConstructor
+public class RegionServiceImpl implements RegionService {
+
+    private final RegionReader regionReader;
 
     public static Map<String, String> parseAddress(String address) {
 
@@ -22,6 +32,26 @@ public class RegionServiceImpl {
         addressMap.put("province", parts[0]); // 시/도
         addressMap.put("district", parts[1]); // 군/구
         return addressMap;
+    }
+
+    /**
+     * 전체 시/도 데이터 목록 조회
+     *
+     * @return 전체 시/도 데이터 목록
+     */
+    @Override
+    public ProvinceListResponse getProvinceList() {
+
+        // Province 객체를 ProvinceListInfo로 변환하여 리스트로 수집
+        List<ProvinceListInfo> provinceListInfos = regionReader.getAllProvinceList().stream()
+                .map(province -> ProvinceListInfo.builder()
+                        .provinceId(province.getId())
+                        .name(province.getProvinceName())
+                        .build())
+                .collect(Collectors.toList());
+
+        // 변환된 리스트로 ProvinceListResponse 생성
+        return new ProvinceListResponse(provinceListInfos);
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
                                 .requestMatchers(GET, "/api/meetings/**").permitAll()
                                 .requestMatchers(GET, "/api/plans/**").permitAll()
                                 .requestMatchers(GET, "/api/reviews/**").permitAll()
+                                .requestMatchers(GET, "/api/regions/**").permitAll()
 
                                 .anyRequest().authenticated()
 

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -39,7 +39,10 @@ public enum ErrorCode {
     ILLEGAL_REVIEW_GRANTED(HttpStatus.UNAUTHORIZED, "본인이 작성한 후기만 수정/삭제가 가능합니다."),
 
     // image
-    ILLEGAL_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "이미지는 한 번에 최대 10개까지 요청 가능합니다.");
+    ILLEGAL_IMAGE_COUNT(HttpStatus.BAD_REQUEST, "이미지는 한 번에 최대 10개까지 요청 가능합니다."),
+
+    // region
+    PROVINCE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 시/도 데이터입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 저장된 전체 지역 목록 조회 기능을 구현했습니다.
- `시/도` 데이터 목록과 해당 `시/도`에 속하는 `군/구` 데이터 목록을 조회할 수 있습니다.
- 군/구 데이터는 `시/도` 데이터의 `id` 값을 기준으로 조회되며, 존재하지 않는 `시/도` 데이터에 대한 군/구 데이터 요청 시 예외가 반환됩니다.
- 데이터 조회는 `stream()`을 사용하여 반복문을 대체하고, 자바 16 이상에서 제공되는 `toList()` 메서드를 사용해 간결하게 리스트를 생성했습니다.
- 해당 기능은 지역 목록 조회 API에서 `GET /api/regions/province`와 `GET /api/regions/district` 엔드포인트를 통해 호출 가능합니다.

### 예외 처리:
- 요청한 `시/도`에 해당하는 군/구 데이터가 없을 경우, `404 Not Found` 상태 코드와 함께 적절한 메시지가 반환됩니다.

### 변경 사항:
- `getDistrictList` 메서드에서 `stream()`을 사용하여 군/구 데이터 목록을 `DistrictListInfo` 객체로 변환 후 리스트로 반환하는 방식으로 구현하였습니다.

<br/>

## 🌱 반영 브랜치
- feat/region-list-49 -> dev
- close #49
