### PR TITLE
[Feat] 토큰 재발급 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -160,7 +160,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/swagger-ui/") ||
                 requestURI.startsWith("/swagger-ui.html") ||
                 requestURI.startsWith("/v3/api-docs") ||
-                requestURI.startsWith("/api/regions");
+                requestURI.startsWith("/api/regions") ||
+                requestURI.equals("/api/auths/reissue");
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -5,12 +5,14 @@ import com.wemo.backend.domain.auth.token.repository.RefreshTokenRepository;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 import static com.wemo.backend.global.exception.ErrorCode.*;
+import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Component
 @RequiredArgsConstructor
@@ -54,6 +56,42 @@ public class RefreshTokenManager {
                 () -> new CustomException(ILLEGAL_REFRESH_TOKEN_NOT_VALID)
         );
 
+    }
+
+    /**
+     * refreshToken 유효성 검증
+     *
+     * @param refreshToken 검증할 refreshToken
+     * @return 유저 아이디 반환, 유효하지 않은 경우 null
+     */
+    public String validateRefreshToken(String refreshToken) {
+
+        Optional<RefreshToken> token = refreshTokenRepository.findByEmail(refreshToken);
+        return token.map(RefreshToken::email).orElse(null);
+    }
+
+    /**
+     * refreshToken 검증하고 새로운 토큰 생성 및 발급
+     *
+     * @param refreshToken 검증할 refreshToken
+     * @return 새로 생성된 accessToken, refreshToken 담은 HttpHeaders
+     */
+    public HttpHeaders reissueToken(String refreshToken) {
+
+        String email = validateRefreshToken(refreshToken);
+        if (email == null) {
+            throw new CustomException(ILLEGAL_REFRESH_TOKEN_NOT_VALID);
+        }
+        // 유효성 검사 후 기존 발급된 refreshToken 삭제
+        refreshTokenRepository.delete(getRefreshToken(refreshToken));
+
+        String newAccessToken = jwtTokenUtils.generateAccessToken(email);
+        String newRefreshToken = jwtTokenUtils.generateRefreshToken(email);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.set(AUTHORIZATION, "Bearer " + newAccessToken);
+        headers.set("Refresh-Token", newRefreshToken);
+        return headers;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/controller/TokenController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/TokenController.java
@@ -1,0 +1,34 @@
+package com.wemo.backend.domain.user.controller;
+
+import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
+import com.wemo.backend.global.response.SuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Token")
+@RestController
+@RequiredArgsConstructor
+public class TokenController {
+
+    private final RefreshTokenManager refreshTokenManager;
+
+    @Operation(summary = "토큰 재발급", description = "accessToken을 재발급합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "accessToken 재발급되었습니다.")
+    })
+    @RequestMapping(value = "/api/auths/reissue", method = RequestMethod.POST)
+    public ResponseEntity<SuccessResponse<String>> reissueToken(@RequestHeader("Refresh-Token") String refreshToken) {
+
+        HttpHeaders httpHeaders = refreshTokenManager.reissueToken(refreshToken);
+        return ResponseEntity.status(200).headers(httpHeaders).body(SuccessResponse.successWithNoData("accessToken 재발급 성공"));
+    }
+}

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
@@ -40,9 +40,9 @@ public class UserController {
 
     @Operation(summary = "회원 가입", description = "사용자를 생성합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "201", description = "사용자가 생성되었습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+            @ApiResponse(responseCode = "201", description = "사용자가 생성되었습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/signup",method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> signup(@Valid @RequestBody UserCreateRequest request) {
@@ -53,9 +53,9 @@ public class UserController {
 
     @Operation(summary = "로그인", description = "사용자가 로그인을 합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+            @ApiResponse(responseCode = "200", description = "로그인에 성공하였습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/signin", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> signin(@Valid @RequestBody SigninRequest request) {
@@ -66,9 +66,9 @@ public class UserController {
 
     @Operation(summary = "로그아웃", description = "사용자가 로그아웃을 합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로그아웃에 성공하였습니다.",
-                    content = @Content(mediaType = "application/json")),
-            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.")
+            @ApiResponse(responseCode = "200", description = "로그아웃에 성공하였습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/signout", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> signout(
@@ -82,8 +82,7 @@ public class UserController {
 
     @Operation(summary = "회원 정보 조회", description = "사용자가 회원 정보를 조회합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "성공적으로 회원 정보를 조회하였습니다.",
-                    content = @Content(mediaType = "application/json"))
+            @ApiResponse(responseCode = "200", description = "성공적으로 회원 정보를 조회하였습니다.")
     })
     @RequestMapping(value = "/users", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
@@ -92,12 +91,12 @@ public class UserController {
 
     @Operation(summary = "회원 정보 수정", description = "사용자가 회원 정보를 수정합니다.")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "회원 정보가 수정되었습니다.",
-                    content = @Content(mediaType = "application/json"))
+            @ApiResponse(responseCode = "200", description = "회원 정보가 수정되었습니다.")
     })
     @RequestMapping(value = "/profile", method = RequestMethod.PUT)
     public ResponseEntity<SuccessResponse<UserUpdateResponse>> updateProfile(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                              @Valid @RequestBody UserUpdateRequest request) {
+
         return ResponseEntity.ok(SuccessResponse.successWithData(userService.updateProfile(userDetails.getUsername(), request)));
     }
 

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -83,6 +83,9 @@ public class SecurityConfig {
                                 "/api/auths/signup",
                                 "/api/auths/signin",
 
+                                // 토큰 재발급 API 경로
+                                "/api/auths/reissue",
+
                                 // swagger 관련 API 문서 경로
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
@@ -17,9 +17,12 @@ public class SwaggerConfig {
                 .components(new Components())
                 .info(apiInfo())
                 .addTagsItem(new Tag().name("Users").description("사용자 관련 API"))
+                .addTagsItem(new Tag().name("Images").description("이미지 관련 API"))
                 .addTagsItem(new Tag().name("Meetings").description("모임 관련 API"))
                 .addTagsItem(new Tag().name("Plans").description("일정 관련 API"))
-                .addTagsItem(new Tag().name("Reviews").description("후기 관련 API"));
+                .addTagsItem(new Tag().name("Reviews").description("후기 관련 API"))
+                .addTagsItem(new Tag().name("Regions").description("지역 관련 API"))
+                .addTagsItem(new Tag().name("Token").description("토큰 관련 API"));
 
     }
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 토큰 재발급 기능을 구현했습니다.
- 유효한 `refreshToken`을 받아 검증한 뒤, 기존 `refreshToken`은 삭제하고 새 `accessToken`과 새 `refreshToken`을 발급하여 헤더에 담아 반환합니다.
- 재발급된 `accessToken`은 기존의 만료된 토큰을 대체하며, 클라이언트는 이를 사용하여 인증을 계속 유지할 수 있습니다.

<br/>

## 🌱 반영 브랜치
- feat/token-reissue-60 -> dev
- close #60 

<br/>
