### PR TITLE
[Refactor] 회원 정보 조회 기능 수정 

### DIFF
--- a/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
@@ -18,4 +18,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     long countByPlan(Plan plan);
 
+    List<Attendance> findAllByUserAndPlanOpened(User user, boolean opened);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
@@ -18,4 +18,6 @@ public interface AttendanceReader {
 
     int getParticipantsCount(Plan plan);
 
+    List<Attendance> getAttendanceByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
@@ -58,4 +58,10 @@ public class AttendanceReaderImpl implements AttendanceReader {
         return (int) attendanceRepository.countByPlan(plan);
     }
 
+    @Override
+    public List<Attendance> getAttendanceByUser(User user) {
+
+        return attendanceRepository.findAllByUserAndPlanOpened(user, true);
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
@@ -5,6 +5,8 @@ import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     boolean existsByUserAndPlan(User user, Plan plan);
@@ -12,5 +14,7 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
     Likes findByUserAndPlan(User user, Plan plan);
 
     int countByPlan(Plan plan);
+
+    List<Likes> findAllByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeReader.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeReader.java
@@ -1,12 +1,17 @@
 package com.wemo.backend.domain.like.service;
 
+import com.wemo.backend.domain.like.entity.Likes;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
+
+import java.util.List;
 
 public interface LikeReader {
 
     void validateLike(User user, Plan plan);
 
     void validateLikeToDelete(User user, Plan plan);
+
+    List<Likes> getLikeCountByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeReaderImpl.java
@@ -1,11 +1,14 @@
 package com.wemo.backend.domain.like.service;
 
+import com.wemo.backend.domain.like.entity.Likes;
 import com.wemo.backend.domain.like.repository.LikeRepository;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.wemo.backend.global.exception.ErrorCode.*;
 
@@ -26,6 +29,12 @@ public class LikeReaderImpl implements LikeReader{
     public void validateLikeToDelete(User user, Plan plan) {
 
         if (!likeRepository.existsByUserAndPlan(user, plan)) throw new CustomException(LIKE_NOT_FOUND);
+    }
+
+    @Override
+    public List<Likes> getLikeCountByUser(User user) {
+
+        return likeRepository.findAllByUser(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -14,4 +14,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
 
     List<Review> findAllByPlan(Plan plan);
 
+    List<Review> findAllByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
@@ -16,4 +16,6 @@ public interface ReviewReader {
 
     void validateReview(User user, Review review);
 
+    List<Review> getReviewByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
@@ -45,4 +45,10 @@ public class ReviewReaderImpl implements ReviewReader {
         if (!user.getEmail().equals(review.getUser().getEmail())) throw new CustomException(ILLEGAL_REVIEW_GRANTED);
     }
 
+    @Override
+    public List<Review> getReviewByUser(User user) {
+
+        return reviewRepository.findAllByUser(user);
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
@@ -22,7 +22,13 @@ public class UserInfoResponse {
 
     private LocalDateTime createdAt;
 
-    public static UserInfoResponse fromEntity(User user) {
+    private int joinedPlanCount;
+
+    private int likedPlanCount;
+
+    private int writtenReviewCount;
+
+    public static UserInfoResponse fromEntity(User user, int joinedPlanCount, int likedPlanCount, int writtenReviewCount) {
 
         return UserInfoResponse.builder()
                 .email(user.getEmail())
@@ -31,6 +37,9 @@ public class UserInfoResponse {
                 .companyName(user.getCompanyName())
                 .loginType(user.getLoginType().getUserType())
                 .createdAt(user.getCreatedAt())
+                .joinedPlanCount(joinedPlanCount)
+                .likedPlanCount(likedPlanCount)
+                .writtenReviewCount(writtenReviewCount)
                 .build();
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -1,11 +1,19 @@
 package com.wemo.backend.domain.user.service;
 
+import com.wemo.backend.domain.attendance.entity.Attendance;
+import com.wemo.backend.domain.attendance.service.AttendanceReader;
 import com.wemo.backend.domain.auth.JwtTokenProvider;
 import com.wemo.backend.domain.auth.UserAuth;
 import com.wemo.backend.domain.auth.token.entity.RefreshToken;
 import com.wemo.backend.domain.auth.token.repository.RefreshTokenRepository;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
+import com.wemo.backend.domain.like.entity.Likes;
+import com.wemo.backend.domain.like.service.LikeReader;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.service.ReviewReader;
 import com.wemo.backend.domain.user.dto.*;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.repository.UserRepository;
@@ -15,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -29,6 +39,9 @@ public class UserServiceImpl implements UserService {
     private final RefreshTokenManager refreshTokenManager;
     private final RefreshTokenRepository refreshTokenRepository;
     private final UserRepository userRepository;
+    private final AttendanceReader attendanceReader;
+    private final LikeReader likeReader;
+    private final ReviewReader reviewReader;
 
     /**
      * 0. 이메일 중복 검사
@@ -111,7 +124,11 @@ public class UserServiceImpl implements UserService {
     public UserInfoResponse getUserInfo(String email) {
 
         User user = userReader.getUserByEmail(email);
-        return UserInfoResponse.fromEntity(user);
+
+        List<Attendance> joinedPlanList = attendanceReader.getAttendanceByUser(user);
+        List<Likes> likedPlanList = likeReader.getLikeCountByUser(user);
+        List<Review> reviewList = reviewReader.getReviewByUser(user);
+        return UserInfoResponse.fromEntity(user, joinedPlanList.size(), likedPlanList.size(), reviewList.size());
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 수정된 피그마를 기반으로 반환되는 데이터 수정하였습니다.
- 유저가 참여한 일정 중 개설 확정된 일정의 개수, 좋아요한 일정의 개수, 작성한 후기 개수도 함께 반환하도록 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/user-getInfo-62 -> dev
- close #62 

<br/>
