### PR TITLE
[Refactor] 일정 목록 조회 기능 수정 

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -74,6 +74,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                 .leftJoin(plan.user, user)
                 .where(listConditions)
                 .where(plan.canceled.eq(false))
+                .where(plan.meeting.deletedAt.isNull())
                 .orderBy(sortField.equals("closeDate") ? plan.registrationEnd.asc() : plan.createdAt.desc())
                 .limit(size)
                 .fetch();
@@ -84,6 +85,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                         .select(plan.count())
                         .from(plan)
                         .where(baseConditions)
+                        .where(plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 
@@ -201,7 +203,11 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         }
 
         if (categoryId != null) {
-            condition = condition.and(plan.meeting.category.id.eq(categoryId));
+            if (categoryId == 1) {
+                condition = condition.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
+            } else {
+                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 id로만 필터링
+            }
         }
 
         return condition;

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
@@ -136,6 +136,7 @@ public class PlanQueryDslImpl implements PlanQueryDsl {
                 .where(baseConditions)
                 .where(likes.user.email.eq(email)) // 유저가 좋아요한 일정
                 .where(plan.canceled.eq(false))
+                .where(plan.meeting.deletedAt.isNull())
                 .orderBy(sortField.equals("closeDate") ? plan.registrationEnd.asc() : plan.createdAt.desc());
 
         List<PlanListResponse> planListResponses = queryBuilder
@@ -152,6 +153,7 @@ public class PlanQueryDslImpl implements PlanQueryDsl {
                         .where(baseConditions)
                         .where(likes.user.email.eq(email)) // 유저가 좋아요한 일정
                         .where(plan.canceled.eq(false))
+                        .where(plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 

--- a/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.entity.QMeeting;
 import com.wemo.backend.domain.review.dto.ReviewListResponse;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
@@ -19,6 +20,7 @@ import java.util.Optional;
 
 import static com.querydsl.jpa.JPAExpressions.select;
 import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
 import static com.wemo.backend.domain.review.entity.QReview.review;
 import static com.wemo.backend.domain.user.entity.QUser.user;
@@ -71,7 +73,8 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                 )
                 .from(review)
                 .leftJoin(review.plan, plan)
-                .leftJoin(review.user, user);
+                .leftJoin(review.user, user)
+                .where(review.plan.meeting.deletedAt.isNull());
 
         // 필터링 적용
         applyFilters(queryBuilder, province, district, startDate, endDate, categoryId, sort);
@@ -89,6 +92,7 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                         .leftJoin(review.plan, plan)
                         .leftJoin(review.user, user)
                         .where(applyFiltersForTotalCount(province, district, startDate, endDate, categoryId)) // 필터를 적용한 메서드 호출
+                        .where(review.plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 
@@ -145,7 +149,11 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
         }
 
         if (categoryId != null) {
-            builder.and(plan.meeting.category.id.eq(categoryId));
+            if (categoryId == 1) {
+                builder.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
+            } else {
+                builder.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 id로만 필터링
+            }
         }
 
         return builder;

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -70,6 +70,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
                 .where(meeting.user.email.eq(email) // 유저가 작성한 모임
                         .or(meetingMember.user.email.eq(email))) // 유저가 가입한 모임
+                .where(meeting.deletedAt.isNull())
                 .groupBy(meeting.id) // 그룹화
                 .orderBy(meeting.createdAt.desc());
 
@@ -87,6 +88,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
                 .where(meeting.user.email.eq(email)
                     .or(meetingMember.user.email.eq(email)))
+                .where(meeting.deletedAt.isNull())
                 .fetchOne()
         ).orElse(0L);
 
@@ -185,6 +187,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(plan.user, user)
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
                 .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
+                .where(plan.meeting.deletedAt.isNull())
                 .orderBy(plan.createdAt.desc());
 
         // 페이징 처리
@@ -200,6 +203,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .from(plan)
                         .leftJoin(attendance).on(attendance.plan.eq(plan))
                         .where(attendance.user.email.eq(email))
+                        .where(plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 
@@ -240,6 +244,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(image).on(image.entityId.eq(review.id) // Image 엔티티와 review.id를 조인
                         .and(image.entityType.eq(Image.EntityType.REVIEW)))
                 .where(review.user.email.eq(email)) // 유저가 작성한 후기만
+                .where(review.plan.meeting.deletedAt.isNull())
                 .orderBy(review.createdAt.desc());
 
         List<UserReviewListResponse> reviewListResponses = queryBuilder
@@ -256,6 +261,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .leftJoin(plan.meeting, meeting)
                         .leftJoin(meeting.category, category)
                         .where(review.user.email.eq(email))
+                        .where(review.plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 
@@ -305,6 +311,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 .and(attendance.reviewed.eq(false)) // 후기 미작성
                                 .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
                 )
+                .where(review.plan.meeting.deletedAt.isNull())
                 .orderBy(plan.createdAt.desc());
 
         List<UserPlanReviewableListResponse> reviewListResponses = queryBuilder
@@ -326,6 +333,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         .and(attendance.reviewed.eq(false)) // 후기 미작성
                                         .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
                         )
+                        .where(review.plan.meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 목록 조회 기능 수정하였습니다.
- 기존 카테고리에 일치하는 일정 목록 반환하던 것을 상위 카테고리 요청 시 해당하는 하위 카테고리 전부의 일정 목록을 반환할 수 있도록 수정하였습니다.
- 모임이 삭제된 경우 관련된 일정과 후기 모두 목록에서 조회되지 않도록 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/plan-list-64 -> dev
- close #64 

<br/>
