### PR TITLE
[Refactor] 모임 상세 조회 기능 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.meeting.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
 import com.wemo.backend.domain.meeting.service.MeetingService;
 import com.wemo.backend.global.response.SuccessResponse;
@@ -13,6 +14,9 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -85,5 +89,21 @@ public class MeetingController {
                                                                  @PathVariable Long meetingId) {
         return ResponseEntity.ok(SuccessResponse.successWithNoData(meetingService.deleteMeeting(userDetails.getUsername(), meetingId)));
     }
+
+    @Operation(summary = "모임 멤버 목록 조회", description = "모임 멤버 목록입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모임에 가입한 멤버의 목록입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{meetingId}/members", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingMemberPagingResponse>> getMemberListByMeeting(@PathVariable Long meetingId,
+                                                                                               @RequestParam(defaultValue = "1") int page,
+                                                                                               @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getMemberListByMeeting(meetingId, pageable)));
+    }
+
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -118,5 +118,19 @@ public class MeetingController {
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getPlanListByMeeting(meetingId, pageable)));
     }
 
+    @Operation(summary = "모임 후기 목록 조회", description = "모임의 전체 후기 목록입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모임의 전체 후기 목록입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{meetingId}/reviews", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingReviewPagingResponse>> getReviewListByMeeting(@PathVariable Long meetingId,
+                                                                                           @RequestParam(defaultValue = "1") int page,
+                                                                                           @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getReviewListByMeeting(meetingId, pageable)));
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -1,10 +1,7 @@
 package com.wemo.backend.domain.meeting.controller;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
-import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
-import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
+import com.wemo.backend.domain.meeting.dto.*;
 import com.wemo.backend.domain.meeting.service.MeetingService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -103,6 +100,22 @@ public class MeetingController {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getMemberListByMeeting(meetingId, pageable)));
+    }
+
+
+    @Operation(summary = "모임 일정 목록 조회", description = "모임의 전체 일정 목록입니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "모임의 전체 일정 목록입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{meetingId}/plans", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingPlanPagingResponse>> getPlanListByMeeting(@PathVariable Long meetingId,
+                                                                                               @RequestParam(defaultValue = "1") int page,
+                                                                                               @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getPlanListByMeeting(meetingId, pageable)));
     }
 
 

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingMemberPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingMemberPagingResponse.java
@@ -1,0 +1,43 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MeetingMemberPagingResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private int memberCount;
+
+    private List<UserListInfo> memberList;
+
+    private int pageSize;
+
+    private int page;
+
+    private int totalPage;
+
+    public MeetingMemberPagingResponse(Meeting meeting, Page<UserListInfo> memberListByMeeting) {
+
+        this.meetingId = meeting.getId();
+        this.meetingName = meeting.getMeetingName();
+        this.memberCount = memberListByMeeting.getContent().size();
+        this.memberList = memberListByMeeting.getContent();
+        this.pageSize = memberListByMeeting.getSize();
+        this.page = memberListByMeeting.getPageable().getPageNumber() + 1;
+        this.totalPage = memberListByMeeting.getTotalPages();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanListResponse.java
@@ -1,0 +1,31 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingPlanListResponse {
+
+    private Long planId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private Long participants;
+
+    private int capacity;
+
+    private String planImagePath;
+
+    @JsonProperty("isOpened")
+    private boolean isOpened;
+
+    @JsonProperty("isFulled")
+    private boolean isFulled;
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanPagingResponse.java
@@ -1,0 +1,40 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingPlanPagingResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private int planCount;
+
+    private List<MeetingPlanListResponse> planList;
+
+    private int pageSize;
+
+    private int page;
+
+    private int totalPage;
+
+    public MeetingPlanPagingResponse(Meeting meeting, Page<MeetingPlanListResponse> planListByMeeting) {
+
+        this.meetingId = meeting.getId();
+        this.meetingName = meeting.getMeetingName();
+        this.planCount = planListByMeeting.getContent().size();
+        this.planList = planListByMeeting.getContent();
+        this.pageSize = planListByMeeting.getSize();
+        this.page = planListByMeeting.getPageable().getPageNumber() + 1;
+        this.totalPage = planListByMeeting.getTotalPages();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewListResponse.java
@@ -1,0 +1,26 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingReviewListResponse {
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private int score;
+
+    private String comment;
+
+    private String reviewImagePath;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewPagingResponse.java
@@ -1,0 +1,39 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingReviewPagingResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private int planCount;
+
+    private List<MeetingReviewListResponse> planList;
+
+    private int pageSize;
+
+    private int page;
+
+    private int totalPage;
+
+    public MeetingReviewPagingResponse(Meeting meeting, Page<MeetingReviewListResponse> reviewListByMeeting) {
+
+        this.meetingId = meeting.getId();
+        this.meetingName = meeting.getMeetingName();
+        this.planCount = reviewListByMeeting.getContent().size();
+        this.planList = reviewListByMeeting.getContent();
+        this.pageSize = reviewListByMeeting.getSize();
+        this.page = reviewListByMeeting.getPageable().getPageNumber() + 1;
+        this.totalPage = reviewListByMeeting.getTotalPages();
+
+    }
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.meeting.repository;
 
 import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import org.springframework.data.domain.Page;
@@ -11,5 +12,7 @@ public interface MeetingQueryDsl {
     Page<UserListInfo> getMemberListByMeeting(Meeting meeting, Pageable pageable);
 
     Page<MeetingPlanListResponse> getPlanListByMeeting(Meeting meeting, Pageable pageable);
+
+    Page<MeetingReviewListResponse> getReviewListByMeeting(Meeting meeting, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -1,0 +1,12 @@
+package com.wemo.backend.domain.meeting.repository;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface MeetingQueryDsl {
+
+    Page<UserListInfo> getMemberListByMeeting(Meeting meeting, Pageable pageable);
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.meeting.repository;
 
+import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import org.springframework.data.domain.Page;
@@ -8,5 +9,7 @@ import org.springframework.data.domain.Pageable;
 public interface MeetingQueryDsl {
 
     Page<UserListInfo> getMemberListByMeeting(Meeting meeting, Pageable pageable);
+
+    Page<MeetingPlanListResponse> getPlanListByMeeting(Meeting meeting, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -6,8 +6,10 @@ import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingReviewPagingResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
-import com.wemo.backend.domain.plan.entity.QPlan;
+import com.wemo.backend.domain.review.entity.QReview;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
@@ -21,6 +23,7 @@ import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
 import static com.wemo.backend.domain.meetingMember.entity.QMeetingMember.meetingMember;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
+import static com.wemo.backend.domain.review.entity.QReview.review;
 import static com.wemo.backend.domain.user.entity.QUser.user;
 
 public class MeetingQueryDslImpl implements MeetingQueryDsl {
@@ -117,6 +120,50 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
         ).orElse(0L);
 
         return new PageImpl<>(planListResponses, pageable, total);
+    }
+
+    @Override
+    public Page<MeetingReviewListResponse> getReviewListByMeeting(Meeting meeting, Pageable pageable) {
+
+        JPAQuery<MeetingReviewListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                MeetingReviewListResponse.class,
+                                user.nickname,
+                                user.profileImagePath,
+                                review.score,
+                                review.comment,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(review.id),
+                                                        image.entityType.eq(Image.EntityType.REVIEW),
+                                                        image.main.eq(true)),
+                                        "reviewImagePath"
+                                ),
+                                review.createdAt,
+                                review.updatedAt
+                        )
+                )
+                .from(review)
+                .leftJoin(review.user, user)
+                .where(review.plan.meeting.eq(meeting))
+                .orderBy(review.createdAt.desc());
+
+        List<MeetingReviewListResponse> reviewListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        long total = Optional.ofNullable(queryFactory
+                .select(review.count())
+                .from(review)
+                .leftJoin(review.user, user)
+                .where(review.plan.meeting.eq(meeting))
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(reviewListResponses, pageable, total);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -1,9 +1,13 @@
 package com.wemo.backend.domain.meeting.repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.entity.QPlan;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
@@ -13,7 +17,10 @@ import org.springframework.data.domain.Pageable;
 import java.util.List;
 import java.util.Optional;
 
+import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
+import static com.wemo.backend.domain.image.entity.QImage.image;
 import static com.wemo.backend.domain.meetingMember.entity.QMeetingMember.meetingMember;
+import static com.wemo.backend.domain.plan.entity.QPlan.plan;
 import static com.wemo.backend.domain.user.entity.QUser.user;
 
 public class MeetingQueryDslImpl implements MeetingQueryDsl {
@@ -56,6 +63,60 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
         ).orElse(0L);
 
         return new PageImpl<>(userListInfos, pageable, total);
+    }
+
+    @Override
+    public Page<MeetingPlanListResponse> getPlanListByMeeting(Meeting meeting, Pageable pageable) {
+
+        JPAQuery<MeetingPlanListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                MeetingPlanListResponse.class,
+                                plan.id,
+                                plan.planName,
+                                plan.dateTime,
+                                Expressions.as(
+                                        queryFactory.select(attendance.count())
+                                                .from(attendance)
+                                                .where(attendance.plan.id.eq(plan.id)
+                                                        .and(attendance.deletedAt.isNull())),
+                                        "participants"
+                                ),
+                                plan.capacity,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
+                                        "planImagePath"
+                                ),
+                                plan.opened,
+                                plan.fulled
+                        )
+                )
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .leftJoin(attendance).on(attendance.plan.eq(plan))
+                .where(plan.meeting.eq(meeting))
+                .orderBy(plan.dateTime.desc());
+
+        List<MeetingPlanListResponse> planListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 전체 멤버 수를 구하는 쿼리 (count)
+        long total = Optional.ofNullable(queryFactory
+                .select(plan.count())
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .leftJoin(attendance).on(attendance.plan.eq(plan))
+                .where(plan.meeting.eq(meeting))
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(planListResponses, pageable, total);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -1,0 +1,61 @@
+package com.wemo.backend.domain.meeting.repository;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.Optional;
+
+import static com.wemo.backend.domain.meetingMember.entity.QMeetingMember.meetingMember;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+public class MeetingQueryDslImpl implements MeetingQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public MeetingQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<UserListInfo> getMemberListByMeeting(Meeting meeting, Pageable pageable) {
+
+        JPAQuery<UserListInfo> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserListInfo.class,
+                                user.nickname,
+                                user.profileImagePath,
+                                user.createdAt
+                        )
+                )
+                .from(meetingMember)
+                .join(meetingMember.user, user)
+                .where(meetingMember.meeting.eq(meeting));
+
+        // 페이징 처리된 회원 목록을 가져옴
+        List<UserListInfo> userListInfos = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 전체 멤버 수를 구하는 쿼리 (count)
+        long total = Optional.ofNullable(queryFactory
+                .select(meetingMember.count())
+                .from(meetingMember)
+                .where(meetingMember.meeting.eq(meeting))
+                .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(userListInfos, pageable, total);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingQueryDsl {
 
     Optional<Meeting> findByIdAndDeletedAtIsNull(Long meetingId);
 

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -21,4 +21,6 @@ public interface MeetingService {
 
     MeetingPlanPagingResponse getPlanListByMeeting(Long meetingId, Pageable pageable);
 
+    MeetingReviewPagingResponse getReviewListByMeeting(Long meetingId, Pageable pageable);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -1,9 +1,6 @@
 package com.wemo.backend.domain.meeting.service;
 
-import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
-import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
+import com.wemo.backend.domain.meeting.dto.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -21,5 +18,7 @@ public interface MeetingService {
     String deleteMeeting(String email, Long meetingId);
 
     MeetingMemberPagingResponse getMemberListByMeeting(Long meetingId, Pageable pageable);
+
+    MeetingPlanPagingResponse getPlanListByMeeting(Long meetingId, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -2,7 +2,9 @@ package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -17,5 +19,7 @@ public interface MeetingService {
     String updateMeeting(String email, Long meetingId, MeetingUpdateRequest request);
 
     String deleteMeeting(String email, Long meetingId);
+
+    MeetingMemberPagingResponse getMemberListByMeeting(Long meetingId, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -4,10 +4,7 @@ import com.wemo.backend.domain.attendance.service.AttendanceReader;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
-import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
-import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
+import com.wemo.backend.domain.meeting.dto.*;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.repository.MeetingRepository;
 import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
@@ -222,6 +219,22 @@ public class MeetingServiceImpl implements MeetingService {
         Meeting meeting = meetingReader.getMeeting(meetingId);
 
         return new MeetingMemberPagingResponse(meeting, meetingRepository.getMemberListByMeeting(meeting, pageable));
+    }
+
+    /**
+     * 모임 일정 목록 조회
+     *
+     * @param meetingId 모임 id
+     * @param pageable 페이징 처리 데이터
+     * @return 모임에 등록된 전체 일정 목록
+     */
+    @Override
+    public MeetingPlanPagingResponse getPlanListByMeeting(Long meetingId, Pageable pageable) {
+
+        // 모임 유효성 검사
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+
+        return new MeetingPlanPagingResponse(meeting, meetingRepository.getPlanListByMeeting(meeting, pageable));
     }
 
     private List<UserListInfo> getUserListInfo(Meeting meeting) {

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -26,6 +26,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -105,14 +106,26 @@ public class MeetingServiceImpl implements MeetingService {
         // 모임 이미지 가져오기
         String meetingImage = imageReader.getImage(meeting.getId(), Image.EntityType.MEETING);
 
-        // 모임 멤버 정보 가져오기
-        List<UserListInfo> userListInfoList = getUserListInfo(meeting);
+        // 모임 멤버 정보 가져오기 (최근 가입한 6명까지)
+        List<UserListInfo> userListInfoList = getUserListInfo(meeting)
+                .stream()
+                .sorted(Comparator.comparing(UserListInfo::getCreatedAt).reversed()) // 가입일 기준 내림차순 정렬
+                .limit(6) // 상위 6명만 가져오기
+                .collect(Collectors.toList());
 
-        // 일정 정보 가져오기
-        List<PlanListInfo> planListInfoList = getPlanListInfo(meeting);
+        // 일정 정보 가져오기 (최근 3개까지)
+        List<PlanListInfo> planListInfoList = getPlanListInfo(meeting)
+                .stream()
+                .sorted(Comparator.comparing(PlanListInfo::getDateTime).reversed()) // 일정 날짜 기준 내림차순 정렬
+                .limit(3) // 상위 3개만 가져오기
+                .collect(Collectors.toList());
 
-        // 리뷰 정보 가져오기
-        List<ReviewListInfo> reviewListInfoList = getReviewListInfo(planListInfoList);
+        // 리뷰 정보 가져오기 (최근 2개까지)
+        List<ReviewListInfo> reviewListInfoList = getReviewListInfo(planListInfoList)
+                .stream()
+                .sorted(Comparator.comparing(ReviewListInfo::getCreatedAt).reversed()) // 작성일 기준 내림차순 정렬
+                .limit(2) // 상위 2개만 가져오기
+                .collect(Collectors.toList());
 
         return MeetingDetailResponse.fromEntity(
                 meeting,

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -6,8 +6,10 @@ import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.dto.MeetingCreateRequest;
 import com.wemo.backend.domain.meeting.dto.MeetingDetailResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingMemberPagingResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingUpdateRequest;
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.repository.MeetingRepository;
 import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
 import com.wemo.backend.domain.meetingMember.service.MeetingMemberStore;
 import com.wemo.backend.domain.plan.dto.PlanListInfo;
@@ -23,6 +25,7 @@ import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -47,6 +50,7 @@ public class MeetingServiceImpl implements MeetingService {
     private final ReviewReader reviewReader;
     private final ImageReader imageReader;
     private final AttendanceReader attendanceReader;
+    private final MeetingRepository meetingRepository;
 
     /**
      * 0. 모임 생성
@@ -202,6 +206,22 @@ public class MeetingServiceImpl implements MeetingService {
         imageReader.deleteImage(meetingId, Image.EntityType.MEETING);
 
         return "모임이 삭제되었습니다.";
+    }
+
+    /**
+     * 모임 멤버 목록 조회
+     *
+     * @param meetingId 모임 id
+     * @param pageable 페이징 처리 데이터
+     * @return 모임에 가입된 전체 멤버 목록
+     */
+    @Override
+    public MeetingMemberPagingResponse getMemberListByMeeting(Long meetingId, Pageable pageable) {
+
+        // 모임 유효성 검사
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+
+        return new MeetingMemberPagingResponse(meeting, meetingRepository.getMemberListByMeeting(meeting, pageable));
     }
 
     private List<UserListInfo> getUserListInfo(Meeting meeting) {

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -237,6 +237,22 @@ public class MeetingServiceImpl implements MeetingService {
         return new MeetingPlanPagingResponse(meeting, meetingRepository.getPlanListByMeeting(meeting, pageable));
     }
 
+    /**
+     * 모임 후기 목록 조회
+     *
+     * @param meetingId 모임 id
+     * @param pageable 페이징 처리 데이터
+     * @return 모임 내의 일정에 등록된 전체 후기 목록
+     */
+    @Override
+    public MeetingReviewPagingResponse getReviewListByMeeting(Long meetingId, Pageable pageable) {
+
+        // 모임 유효성 검사
+        Meeting meeting = meetingReader.getMeeting(meetingId);
+
+        return new MeetingReviewPagingResponse(meeting, meetingRepository.getReviewListByMeeting(meeting, pageable));
+    }
+
     private List<UserListInfo> getUserListInfo(Meeting meeting) {
         return meetingMemberReader.getMemberListByMeeting(meeting).stream()
                 .map(UserListInfo::fromEntity)

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserListInfo.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.user.dto;
 
 import com.wemo.backend.domain.attendance.entity.Attendance;
 import com.wemo.backend.domain.meetingMember.entity.MeetingMember;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@AllArgsConstructor
 public class UserListInfo {
 
     private String nickname;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 상세 조회 시 **가입 멤버는 최대 6명**, **일정은 최근 3개**, **후기는 최근 2개**로 제한하여 반환하도록 수정하였습니다.
- 제한된 데이터 외에 **전체 데이터를 조회**할 수 있도록 각각 페이징 처리된 목록을 반환하는 기능을 추가하였습니다.
- 기존 로직을 수정하여 성능 최적화를 도모하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/meeting-detail-66` -> `dev`
- close #66

<br/>
