### PR TITLE
[Refactor] 모임 생성 및 상세 조회 기능 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/comm/CommUtilService.java
+++ b/src/main/java/com/wemo/backend/domain/comm/CommUtilService.java
@@ -1,0 +1,19 @@
+package com.wemo.backend.domain.comm;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import com.wemo.backend.domain.user.entity.User;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface CommUtilService {
+
+    List<UserListInfo> getUserListInfo(Meeting meeting);
+
+    double calculateReviewAverage(Meeting meeting);
+
+    void validateMeetingOwner(User user, Meeting meeting);
+
+}

--- a/src/main/java/com/wemo/backend/domain/comm/CommUtilServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/comm/CommUtilServiceImpl.java
@@ -1,0 +1,83 @@
+package com.wemo.backend.domain.comm;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.service.ReviewReader;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import com.wemo.backend.domain.user.entity.User;
+import com.wemo.backend.global.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_GRANTED;
+
+@Service
+@RequiredArgsConstructor
+public class CommUtilServiceImpl implements CommUtilService {
+
+    private final PlanReader planReader;
+
+    private final ReviewReader reviewReader;
+
+    private final MeetingMemberReader meetingMemberReader;
+
+    /**
+     * 모임의 전체 멤버 목록 반환
+     *
+     * @param meeting 모임 객체
+     * @return 멤버 목록
+     */
+    public List<UserListInfo> getUserListInfo(Meeting meeting) {
+
+        return meetingMemberReader.getMemberListByMeeting(meeting).stream()
+                .map(UserListInfo::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 모임에 대한 평균 평점 계산
+     *
+     * @param meeting 모임 객체
+     * @return 평균 평점
+     */
+    @Override
+    public double calculateReviewAverage(Meeting meeting) {
+
+        List<Plan> plans = planReader.getPlanByMeeting(meeting);
+        if (plans.isEmpty()) {
+            return 0;
+        }
+        double totalScore = 0;
+        int totalReviews = 0;
+        for (Plan plan : plans) {
+            List<Review> reviews = reviewReader.getReviewByPlan(plan);
+            for (Review review : reviews) {
+                totalScore += review.getScore();
+                totalReviews++;
+            }
+        }
+        return totalReviews == 0 ? 0 : totalScore / totalReviews;
+    }
+
+    /**
+     * 모임의 소유자가 요청한 사용자인지 검증
+     *
+     * @param user    사용자 객체
+     * @param meeting 모임 객체
+     * @throws CustomException 권한이 없는 경우 예외 발생
+     */
+    @Override
+    public void validateMeetingOwner(User user, Meeting meeting) {
+
+        if (!meeting.getUser().getEmail().equals(user.getEmail())) {
+            throw new CustomException(ILLEGAL_MEETING_GRANTED);
+        }
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
-    Image findByEntityIdAndEntityType(Long entityId, Image.EntityType entityType);
+    Image findByEntityIdAndEntityTypeAndMainIsTrue(Long entityId, Image.EntityType entityType);
 
     List<Image> findAllByEntityIdAndEntityType(Long entityId, Image.EntityType entityType);
 

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 public interface ImageReader {
 
-    String getImage(Long entityId, Image.EntityType entityType);
+    String getMainImage(Long entityId, Image.EntityType entityType);
 
     List<String> getImageList(Long entityId, Image.EntityType entityType);
 

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
@@ -16,9 +16,9 @@ public class ImageReaderImpl implements ImageReader {
     private final ImageRepository imageRepository;
 
     @Override
-    public String getImage(Long entityId, Image.EntityType entityType) {
+    public String getMainImage(Long entityId, Image.EntityType entityType) {
 
-        return imageRepository.findByEntityIdAndEntityType(entityId, entityType).getFileUrl();
+        return imageRepository.findByEntityIdAndEntityTypeAndMainIsTrue(entityId, entityType).getFileUrl();
     }
 
     @Override
@@ -38,6 +38,7 @@ public class ImageReaderImpl implements ImageReader {
     @Override
     @Transactional
     public void deleteImage(Long entityId, Image.EntityType entityType) {
+
         List<Image> imageList = imageRepository.findAllByEntityIdAndEntityType(entityId, entityType);
         imageRepository.deleteAll(imageList); // 이미지 삭제
     }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateRequest.java
@@ -1,8 +1,13 @@
 package com.wemo.backend.domain.meeting.dto;
 
-import jakarta.validation.constraints.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -21,6 +26,6 @@ public class MeetingCreateRequest {
     private Long categoryId;
 
     @NotBlank(message = "모임 대표 이미지는 필수 입력 값입니다.")
-    private String fileUrl;
+    private List<String> fileUrls;
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
@@ -18,7 +18,7 @@ public class MeetingDetailResponse {
 
     private String meetingName;
 
-    private String meetingImagePath;
+    private List<String> meetingImagePath;
 
     private int memberCount;
 
@@ -42,9 +42,11 @@ public class MeetingDetailResponse {
 
     private int reviewCounts;
 
+    private double reviewAverage;
+
     private List<ReviewListInfo> reviewList;
 
-    public static MeetingDetailResponse fromEntity(Meeting meeting, String meetingImage, int memberCount, List<UserListInfo> userListInfoList, int planCounts, List<PlanListInfo> planListInfoList, int reviewCounts, List<ReviewListInfo> reviewListInfoList) {
+    public static MeetingDetailResponse fromEntity(Meeting meeting, List<String> meetingImage, int memberCount, List<UserListInfo> userListInfoList, int planCounts, List<PlanListInfo> planListInfoList, int reviewCounts, double reviewAverage, List<ReviewListInfo> reviewListInfoList) {
 
         return MeetingDetailResponse.builder()
                 .meetingId(meeting.getId())
@@ -59,6 +61,7 @@ public class MeetingDetailResponse {
                 .updatedAt(meeting.getUpdatedAt())
                 .memberList(userListInfoList)
                 .planCounts(planCounts)
+                .reviewAverage(reviewAverage)
                 .planList(planListInfoList)
                 .reviewCounts(reviewCounts)
                 .reviewList(reviewListInfoList)

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
@@ -1,6 +1,5 @@
 package com.wemo.backend.domain.meeting.dto;
 
-import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingInfoResponse.java
@@ -16,13 +16,19 @@ public class MeetingInfoResponse {
 
     private String meetingImagePath;
 
-    public static MeetingInfoResponse fromEntity(Meeting meeting, String meetingImagePath) {
+    private int memberCount;
+
+    private double reviewAverage;
+
+    public static MeetingInfoResponse fromEntity(Meeting meeting, int memberCount, double reviewAverage, String meetingImagePath) {
 
         return MeetingInfoResponse.builder()
                 .meetingId(meeting.getId())
                 .meetingName(meeting.getMeetingName())
                 .description(meeting.getDescription())
                 .meetingImagePath(meetingImagePath)
+                .memberCount(memberCount)
+                .reviewAverage(reviewAverage)
                 .build();
     }
 

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingReviewPagingResponse.java
@@ -15,9 +15,9 @@ public class MeetingReviewPagingResponse {
 
     private String meetingName;
 
-    private int planCount;
+    private int reviewCount;
 
-    private List<MeetingReviewListResponse> planList;
+    private List<MeetingReviewListResponse> reviewList;
 
     private int pageSize;
 
@@ -29,11 +29,12 @@ public class MeetingReviewPagingResponse {
 
         this.meetingId = meeting.getId();
         this.meetingName = meeting.getMeetingName();
-        this.planCount = reviewListByMeeting.getContent().size();
-        this.planList = reviewListByMeeting.getContent();
+        this.reviewCount = reviewListByMeeting.getContent().size();
+        this.reviewList = reviewListByMeeting.getContent();
         this.pageSize = reviewListByMeeting.getSize();
         this.page = reviewListByMeeting.getPageable().getPageNumber() + 1;
         this.totalPage = reviewListByMeeting.getTotalPages();
 
     }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -7,9 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingReviewPagingResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
-import com.wemo.backend.domain.review.entity.QReview;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import jakarta.persistence.EntityManager;
 import org.springframework.data.domain.Page;
@@ -102,7 +100,8 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                 .leftJoin(plan.user, user)
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
                 .where(plan.meeting.eq(meeting))
-                .orderBy(plan.dateTime.desc());
+                .orderBy(plan.dateTime.desc())
+                .groupBy(plan.id);
 
         List<MeetingPlanListResponse> planListResponses = queryBuilder
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -1,36 +1,25 @@
 package com.wemo.backend.domain.meeting.service;
 
-import com.wemo.backend.domain.attendance.service.AttendanceReader;
+import com.wemo.backend.domain.comm.CommUtilService;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageReader;
 import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.dto.*;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.repository.MeetingRepository;
-import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
 import com.wemo.backend.domain.meetingMember.service.MeetingMemberStore;
 import com.wemo.backend.domain.plan.dto.PlanListInfo;
-import com.wemo.backend.domain.plan.entity.Plan;
-import com.wemo.backend.domain.plan.service.PlanReader;
 import com.wemo.backend.domain.review.dto.ReviewListInfo;
-import com.wemo.backend.domain.review.entity.Review;
-import com.wemo.backend.domain.review.service.ReviewReader;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
-import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_MEETING_GRANTED;
 
 @Slf4j
 @Service
@@ -42,96 +31,70 @@ public class MeetingServiceImpl implements MeetingService {
     private final MeetingMemberStore meetingMemberStore;
     private final ImageStore imageStore;
     private final MeetingReader meetingReader;
-    private final MeetingMemberReader meetingMemberReader;
-    private final PlanReader planReader;
-    private final ReviewReader reviewReader;
     private final ImageReader imageReader;
-    private final AttendanceReader attendanceReader;
     private final MeetingRepository meetingRepository;
+    private final CommUtilService commUtilService;
+    private final MeetingUtilService meetingUtilService;
 
     /**
-     * 0. 모임 생성
+     * 모임 생성
+     * - 사용자 인증을 통해 요청한 사용자가 유효한지 확인하고, 모임 저장
+     * - 모임에 대한 이미지 파일 저장
+     * - 모임 주최자는 자동으로 가입되도록 설정
      *
-     * @param email   이메일
-     * @param request 모임 생성 데이터 (모임명, 모임 설명, 카테고리, 모임 이미지)
+     * @param email   사용자의 이메일
+     * @param request 모임 생성 요청 객체
      */
     @Override
     @Transactional
     public void createMeeting(String email, MeetingCreateRequest request) {
 
-        // 유저 객체 검증
-        User user = userReader.getUserByEmail(email);
-
-        // 모임 객체 저장
+        User user = validateUser(email);
         Meeting meeting = meetingStore.storeMeeting(request, user);
-
-        // 모임 대표 이미지 저장
-        Image image = imageStore.storeImage(user, meeting.getId(), request.getFileUrl(), Image.EntityType.MEETING);
-
-        // 모임 생성자는 자동으로 가입
+        imageStore.storeImageList(user, meeting.getId(), request.getFileUrls(), Image.EntityType.MEETING);
         meetingMemberStore.storeMemberToMeeting(user, meeting);
-
         log.info("사용자 {}의 모임 id {}가 생성되었습니다.", user.getEmail(), meeting.getId());
-
     }
 
     /**
      * 모임 가입
+     * - 사용자 인증 후 모임에 참여할 수 있도록 설정
      *
-     * @param email     이메일
+     * @param email     사용자의 이메일
      * @param meetingId 모임 id
-     * @return 성공 응답 메세지
+     * @return 모임 가입 성공 메시지
      */
     @Override
     @Transactional
     public String joinMeeting(String email, Long meetingId) {
 
-        User user = userReader.getUserByEmail(email);
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
+        User user = validateUser(email);
+        Meeting meeting = validateMeeting(meetingId);
         meetingMemberStore.storeMemberToMeeting(user, meeting);
         log.info("사용자 {}가 모임 id {}에 가입했습니다.", user.getEmail(), meeting.getId());
-
         return "모임 가입 성공";
     }
 
     /**
-     * 모임 상세 조회
+     * 모임 상세 정보 조회
+     * - 모임에 대한 이미지, 멤버, 일정, 후기 정보를 포함하여 반환
+     * - 후기는 전체 일정의 평균 평점을 포함
      *
      * @param meetingId 모임 id
-     * @return 모임에 관련된 모든 정보 반환 (모임 정보, 멤버 리스트, 일정 리스트, 후기 리스트)
+     * @return 모임 상세 정보 응답 객체
      */
     @Override
     public MeetingDetailResponse getMeetingDetail(Long meetingId) {
 
-        log.info("모임 id {}의 상세 조회 요청", meetingId);
+        log.info("모임 id {} 상세 조회 요청", meetingId);
+        Meeting meeting = validateMeeting(meetingId);
 
-        // 모임 유효성 검사
-        Meeting meeting = meetingReader.getMeeting(meetingId);
+        List<String> meetingImage = imageReader.getImageList(meeting.getId(), Image.EntityType.MEETING);
+        List<UserListInfo> userListInfoList = meetingUtilService.getTopUsers(meeting);
+        List<PlanListInfo> planListInfoList = meetingUtilService.getTopPlans(meeting);
+        List<ReviewListInfo> reviewListInfoList = meetingUtilService.getTopReviews(planListInfoList);
 
-        // 모임 이미지 가져오기
-        String meetingImage = imageReader.getImage(meeting.getId(), Image.EntityType.MEETING);
-
-        // 모임 멤버 정보 가져오기 (최근 가입한 6명까지)
-        List<UserListInfo> userListInfoList = getUserListInfo(meeting)
-                .stream()
-                .sorted(Comparator.comparing(UserListInfo::getCreatedAt).reversed()) // 가입일 기준 내림차순 정렬
-                .limit(6) // 상위 6명만 가져오기
-                .collect(Collectors.toList());
-
-        // 일정 정보 가져오기 (최근 3개까지)
-        List<PlanListInfo> planListInfoList = getPlanListInfo(meeting)
-                .stream()
-                .sorted(Comparator.comparing(PlanListInfo::getDateTime).reversed()) // 일정 날짜 기준 내림차순 정렬
-                .limit(3) // 상위 3개만 가져오기
-                .collect(Collectors.toList());
-
-        // 리뷰 정보 가져오기 (최근 2개까지)
-        List<ReviewListInfo> reviewListInfoList = getReviewListInfo(planListInfoList)
-                .stream()
-                .sorted(Comparator.comparing(ReviewListInfo::getCreatedAt).reversed()) // 작성일 기준 내림차순 정렬
-                .limit(2) // 상위 2개만 가져오기
-                .collect(Collectors.toList());
+        double reviewAverage = commUtilService.calculateReviewAverage(meeting);
 
         return MeetingDetailResponse.fromEntity(
                 meeting,
@@ -141,41 +104,39 @@ public class MeetingServiceImpl implements MeetingService {
                 planListInfoList.size(),
                 planListInfoList,
                 reviewListInfoList.size(),
+                reviewAverage,
                 reviewListInfoList
         );
     }
 
     /**
-     * 모임 정보 수정
+     * 모임 수정
+     * - 모임의 설명을 수정할 수 있으며, 모임의 소유자만 수정 가능
      *
-     * @param email     이메일
+     * @param email     사용자의 이메일
      * @param meetingId 모임 id
-     * @param request   수정 요청 데이터 (모임 설명)
-     * @return 성공 메세지
+     * @param request   모임 수정 요청 객체
+     * @return 모임 수정 성공 메시지
      */
     @Override
     @Transactional
     public String updateMeeting(String email, Long meetingId, MeetingUpdateRequest request) {
 
-        User user = userReader.getUserByEmail(email);
-
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
-        if (!meeting.getUser().getEmail().equals(user.getEmail())) throw new CustomException(ILLEGAL_MEETING_GRANTED);
-
+        User user = validateUser(email);
+        Meeting meeting = validateMeeting(meetingId);
+        commUtilService.validateMeetingOwner(user, meeting);
         meeting.updateDescription(request.getDescription());
-
-        log.info("모임 id {}가 수정되었습니다.", meeting.getId());
-
+        log.info("사용자 {}의 모임 id {}가 수정되었습니다.", user.getEmail(), meeting.getId());
         return "모임 내용이 수정되었습니다.";
     }
 
     /**
      * 모임 삭제
+     * - 모임과 관련된 모든 데이터(일정, 후기, 멤버 등) 삭제
      *
-     * @param email     이메일
+     * @param email     사용자의 이메일
      * @param meetingId 모임 id
-     * @return
+     * @return 모임 삭제 성공 메시지
      */
     @Override
     @Transactional
@@ -183,127 +144,100 @@ public class MeetingServiceImpl implements MeetingService {
 
         log.info("모임 id {}의 삭제 요청", meetingId);
 
-        User user = userReader.getUserByEmail(email);
+        User user = validateUser(email);
+        Meeting meeting = validateMeeting(meetingId);
+        commUtilService.validateMeetingOwner(user, meeting);
 
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
-        if (!meeting.getUser().getEmail().equals(user.getEmail())) {
-            log.warn("사용자 {}가 권한 없이 모임 id {}를 삭제하려 했습니다.", user.getEmail(), meetingId);
-            throw new CustomException(ILLEGAL_MEETING_GRANTED);
-        }
-
-        // 모임 삭제 처리
+        // 모임 소프트 삭제
         meeting.softDelete();
 
-        // 모임과 연관된 계획 정보 조회
-        List<Plan> plans = planReader.getPlanByMeeting(meeting);
-        plans.forEach(plan -> {
-            // 계획에 속한 참석자 정보 삭제
-            attendanceReader.getAttendanceList(plan).forEach(attendanceReader::delete);
-            // 후기 정보 삭제
-            reviewReader.getReviewByPlan(plan).forEach(review -> {
-                // 후기와 관련된 이미지 삭제
-                imageReader.deleteImage(review.getId(), Image.EntityType.REVIEW);
-                reviewReader.delete(review);
-            });
-            // 계획에 속한 이미지 삭제
-            imageReader.deleteImage(plan.getId(), Image.EntityType.PLAN);
-            // 계획 정보 삭제
-            planReader.delete(plan);
-        });
-
-        // 모임과 연관된 멤버 정보 삭제
-        meetingMemberReader.getMemberListByMeeting(meeting).forEach(meetingMemberReader::delete);
-
-        // 모임에 속한 이미지 삭제
-        imageReader.deleteImage(meetingId, Image.EntityType.MEETING);
+        // 관련 데이터 삭제
+        deleteAssociatedData(meeting);
 
         log.info("사용자 {}가 모임 id {}를 정상적으로 삭제했습니다.", user.getEmail(), meeting.getId());
-
         return "모임이 삭제되었습니다.";
     }
 
     /**
      * 모임 멤버 목록 조회
+     * - 페이징 처리된 멤버 목록 반환
      *
      * @param meetingId 모임 id
-     * @param pageable  페이징 처리 데이터
-     * @return 모임에 가입된 전체 멤버 목록
+     * @param pageable  페이지네이션 정보
+     * @return 모임 멤버 페이징 응답 객체
      */
     @Override
     public MeetingMemberPagingResponse getMemberListByMeeting(Long meetingId, Pageable pageable) {
 
-        // 모임 유효성 검사
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
+        Meeting meeting = validateMeeting(meetingId);
         return new MeetingMemberPagingResponse(meeting, meetingRepository.getMemberListByMeeting(meeting, pageable));
     }
 
     /**
      * 모임 일정 목록 조회
+     * - 페이징 처리된 일정 목록 반환
      *
      * @param meetingId 모임 id
-     * @param pageable  페이징 처리 데이터
-     * @return 모임에 등록된 전체 일정 목록
+     * @param pageable  페이지네이션 정보
+     * @return 모임 일정 페이징 응답 객체
      */
     @Override
     public MeetingPlanPagingResponse getPlanListByMeeting(Long meetingId, Pageable pageable) {
 
-        // 모임 유효성 검사
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
+        Meeting meeting = validateMeeting(meetingId);
         return new MeetingPlanPagingResponse(meeting, meetingRepository.getPlanListByMeeting(meeting, pageable));
     }
 
     /**
      * 모임 후기 목록 조회
+     * - 페이징 처리된 후기 목록 반환
      *
      * @param meetingId 모임 id
-     * @param pageable  페이징 처리 데이터
-     * @return 모임 내의 일정에 등록된 전체 후기 목록
+     * @param pageable  페이지네이션 정보
+     * @return 모임 후기 페이징 응답 객체
      */
     @Override
     public MeetingReviewPagingResponse getReviewListByMeeting(Long meetingId, Pageable pageable) {
 
-        // 모임 유효성 검사
-        Meeting meeting = meetingReader.getMeeting(meetingId);
-
+        Meeting meeting = validateMeeting(meetingId);
         return new MeetingReviewPagingResponse(meeting, meetingRepository.getReviewListByMeeting(meeting, pageable));
     }
 
-    private List<UserListInfo> getUserListInfo(Meeting meeting) {
+    // 유틸리티 메서드들
 
-        return meetingMemberReader.getMemberListByMeeting(meeting).stream()
-                .map(UserListInfo::fromEntity)
-                .collect(Collectors.toList());
+    /**
+     * 사용자 이메일을 통해 사용자를 검증
+     *
+     * @param email 사용자 이메일
+     * @return 검증된 사용자 객체
+     */
+    private User validateUser(String email) {
+
+        return userReader.getUserByEmail(email);
     }
 
-    private List<PlanListInfo> getPlanListInfo(Meeting meeting) {
+    /**
+     * 모임 id를 통해 모임을 검증
+     *
+     * @param meetingId 모임 id
+     * @return 검증된 모임 객체
+     */
+    private Meeting validateMeeting(Long meetingId) {
 
-        List<Plan> planList = planReader.getPlanByMeeting(meeting);
-
-        return planList.stream().map(plan -> {
-            List<String> planImageList = imageReader.getImageList(plan.getId(), Image.EntityType.PLAN);
-
-            return PlanListInfo.fromEntity(plan, attendanceReader.getParticipantsCount(plan), planImageList);
-        }).collect(Collectors.toList());
+        return meetingReader.getMeeting(meetingId);
     }
 
-    private List<ReviewListInfo> getReviewListInfo(List<PlanListInfo> planListInfoList) {
+    /**
+     * 모임에 대한 모든 연관 데이터를 삭제
+     * - 일정, 후기, 이미지, 멤버 데이터 삭제
+     *
+     * @param meeting 모임 객체
+     */
+    private void deleteAssociatedData(Meeting meeting) {
 
-        List<ReviewListInfo> reviewListInfoList = new ArrayList<>();
-
-        for (PlanListInfo planListInfo : planListInfoList) {
-            Plan plan = planReader.getPlan(planListInfo.getPlanId());
-            List<Review> reviews = reviewReader.getReviewByPlan(plan);
-
-            reviews.forEach(review -> {
-                ReviewListInfo reviewListInfo = ReviewListInfo.fromEntity(review);
-                reviewListInfoList.add(reviewListInfo);
-            });
-        }
-
-        return reviewListInfoList;
+        meetingUtilService.deletePlansAndReviews(meeting);
+        meetingUtilService.deleteMembers(meeting);
+        meetingUtilService.deleteMeetingImages(meeting);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilService.java
@@ -1,0 +1,26 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.plan.dto.PlanListInfo;
+import com.wemo.backend.domain.review.dto.ReviewListInfo;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public interface MeetingUtilService {
+
+    List<UserListInfo> getTopUsers(Meeting meeting);
+
+    List<PlanListInfo> getTopPlans(Meeting meeting);
+
+    List<ReviewListInfo> getTopReviews(List<PlanListInfo> plans);
+
+    void deletePlansAndReviews(Meeting meeting);
+
+    void deleteMembers(Meeting meeting);
+
+    void deleteMeetingImages(Meeting meeting);
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilServiceImpl.java
@@ -1,0 +1,195 @@
+package com.wemo.backend.domain.meeting.service;
+
+import com.wemo.backend.domain.attendance.service.AttendanceReader;
+import com.wemo.backend.domain.comm.CommUtilService;
+import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.image.service.ImageReader;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
+import com.wemo.backend.domain.plan.dto.PlanListInfo;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
+import com.wemo.backend.domain.review.dto.ReviewListInfo;
+import com.wemo.backend.domain.review.entity.Review;
+import com.wemo.backend.domain.review.service.ReviewReader;
+import com.wemo.backend.domain.user.dto.UserListInfo;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class MeetingUtilServiceImpl implements MeetingUtilService {
+
+    private final CommUtilService commUtilService;
+
+    private final PlanReader planReader;
+
+    private final ReviewReader reviewReader;
+
+    private final ImageReader imageReader;
+
+    private final MeetingMemberReader meetingMemberReader;
+
+    private final AttendanceReader attendanceReader;
+
+    private static final Comparator<UserListInfo> USER_DATE_DESC = Comparator.comparing(UserListInfo::getCreatedAt).reversed();
+    private static final Comparator<PlanListInfo> PLAN_DATE_DESC = Comparator.comparing(PlanListInfo::getDateTime).reversed();
+    private static final Comparator<ReviewListInfo> REVIEW_DATE_DESC = Comparator.comparing(ReviewListInfo::getCreatedAt).reversed();
+
+    /**
+     * 모임의 최근 가입자 6명 조회
+     *
+     * @param meeting 모임 객체
+     * @return 최근 가입자 목록
+     */
+    @Override
+    public List<UserListInfo> getTopUsers(Meeting meeting) {
+
+        return commUtilService.getUserListInfo(meeting).stream()
+                .sorted(USER_DATE_DESC)
+                .limit(6)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 모임의 최근 3개 일정 조회
+     *
+     * @param meeting 모임 객체
+     * @return 최근 일정 목록
+     */
+    @Override
+    public List<PlanListInfo> getTopPlans(Meeting meeting) {
+
+        return getPlanListInfo(meeting).stream()
+                .sorted(PLAN_DATE_DESC)
+                .limit(3)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 모임 일정에 대한 최근 2개 후기 조회
+     *
+     * @param plans 일정 목록
+     * @return 최근 후기 목록
+     */
+    @Override
+    public List<ReviewListInfo> getTopReviews(List<PlanListInfo> plans) {
+
+        return getReviewListInfo(plans).stream()
+                .sorted(REVIEW_DATE_DESC)
+                .limit(2)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 모임에 대한 모든 일정과 후기, 이미지를 삭제
+     *
+     * @param meeting 모임 객체
+     */
+    @Override
+    public void deletePlansAndReviews(Meeting meeting) {
+
+        List<Plan> plans = planReader.getPlanByMeeting(meeting);
+
+        for (Plan plan : plans) {
+            deleteReviews(plan);
+            deletePlanImages(plan);
+        }
+    }
+
+    /**
+     * 일정에 대한 모든 후기를 삭제
+     *
+     * @param plan 일정 객체
+     */
+    private void deleteReviews(Plan plan) {
+
+        List<Review> reviews = reviewReader.getReviewByPlan(plan);
+
+        for (Review review : reviews) {
+            deleteReviewImages(review);
+            reviewReader.delete(review);
+        }
+    }
+
+    /**
+     * 리뷰에 대한 이미지를 삭제
+     *
+     * @param review 리뷰 객체
+     */
+    private void deleteReviewImages(Review review) {
+
+        imageReader.deleteImage(review.getId(), Image.EntityType.REVIEW);
+    }
+
+    /**
+     * 일정에 대한 이미지를 삭제
+     *
+     * @param plan 일정 객체
+     */
+    private void deletePlanImages(Plan plan) {
+
+        imageReader.deleteImage(plan.getId(), Image.EntityType.PLAN);
+    }
+
+    /**
+     * 모임에 대한 모든 멤버 데이터를 삭제
+     *
+     * @param meeting 모임 객체
+     */
+    @Override
+    public void deleteMembers(Meeting meeting) {
+
+        meetingMemberReader.getMemberListByMeeting(meeting)
+                .forEach(meetingMemberReader::delete);
+    }
+
+    /**
+     * 모임에 대한 이미지를 삭제
+     *
+     * @param meeting 모임 객체
+     */
+    @Override
+    public void deleteMeetingImages(Meeting meeting) {
+
+        imageReader.deleteImage(meeting.getId(), Image.EntityType.MEETING);
+    }
+
+    /**
+     * 모임의 전체 일정 목록 조회
+     *
+     * @param meeting 모임 객체
+     * @return 일정 목록
+     */
+    private List<PlanListInfo> getPlanListInfo(Meeting meeting) {
+
+        return planReader.getPlanByMeeting(meeting).stream()
+                .map(plan -> {
+                    List<String> planImageList = imageReader.getImageList(plan.getId(), Image.EntityType.PLAN);
+                    return PlanListInfo.fromEntity(plan, attendanceReader.getParticipantsCount(plan), planImageList);
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 모임 일정에 대한 후기 목록 반환
+     *
+     * @param planListInfoList 일정 목록
+     * @return 후기 목록
+     */
+    private List<ReviewListInfo> getReviewListInfo(List<PlanListInfo> planListInfoList) {
+
+        List<ReviewListInfo> reviewListInfoList = new ArrayList<>();
+        for (PlanListInfo planListInfo : planListInfoList) {
+            Plan plan = planReader.getPlan(planListInfo.getPlanId());
+            reviewReader.getReviewByPlan(plan).forEach(review -> reviewListInfoList.add(ReviewListInfo.fromEntity(review)));
+        }
+        return reviewListInfoList;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -16,4 +16,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQue
 
     List<Review> findAllByUser(User user);
 
+    void deleteAllByPlan(Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -57,39 +57,18 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request) {
 
-        // 유저 유효성 검사
         User user = userReader.getUserByEmail(email);
-        // 일정 유효성 검사
         Plan plan = planReader.getPlan(planId);
 
-        // 기존 후기 작성 여부 확인
-        boolean hasExistingReview = reviewRepository.existsByUserAndPlan(user, plan);
-        if (hasExistingReview) {
-            throw new CustomException(REVIEW_ALREADY_EXISTS);
-        }
+        checkExistingReview(user, plan);
+        checkPlanEndTime(plan);
 
-        // 일정이 완료되었는지 확인
-        if (plan.getDateTime().isAfter(LocalDateTime.now())) {
-            throw new CustomException(REVIEW_CREATION_BEFORE_PLAN_END);
-        }
-
-        // 참여 내역 검사 후 상태값 변경
         Attendance attendance = attendanceReader.validateAttendance(user, plan);
         attendance.updateStatus();
 
-        // 후기 저장
         Review review = reviewStore.storeReview(request, user, plan);
 
-        // 이미지 저장 (선택)
-        if (request.getFileUrls() != null || !request.getFileUrls().isEmpty()) {
-            List<String> imageList = imageStore.storeImageList(user, review.getId(), request.getFileUrls(), Image.EntityType.REVIEW);
-            return ReviewCreateResponse.fromEntityWithImage(plan, review, imageList);
-        }
-
-        log.info("사용자 {}가 일정 id {}에 후기를 등록했습니다.", user.getEmail(), plan.getId());
-
-        return ReviewCreateResponse.fromEntity(plan, review);
-
+        return storeReviewAndImages(user, plan, request, review);
     }
 
     /**
@@ -113,7 +92,7 @@ public class ReviewServiceImpl implements ReviewService {
     /**
      * 후기 수정
      *
-     * @param email    이메일
+     * @param email    사용자 이메일
      * @param reviewId 후기 id
      * @param request  후기 수정 데이터 (평점, 내용, 이미지)
      * @return 수정된 후기 정보
@@ -143,7 +122,7 @@ public class ReviewServiceImpl implements ReviewService {
     /**
      * 후기 삭제
      *
-     * @param email    이메일
+     * @param email    사용자 이메일
      * @param reviewId 후기 id
      * @return 성공 메세지
      */
@@ -161,6 +140,30 @@ public class ReviewServiceImpl implements ReviewService {
         log.info("사용자 {}가 일정 id {}의 후기 id {}를 삭제했습니다.", user.getEmail(), review.getPlan().getId(), review.getId());
 
         return "후기가 정상적으로 삭제되었습니다.";
+    }
+
+    private void checkExistingReview(User user, Plan plan) {
+
+        boolean hasExistingReview = reviewRepository.existsByUserAndPlan(user, plan);
+        if (hasExistingReview) {
+            throw new CustomException(REVIEW_ALREADY_EXISTS);
+        }
+    }
+
+    private void checkPlanEndTime(Plan plan) {
+
+        if (plan.getDateTime().isAfter(LocalDateTime.now())) {
+            throw new CustomException(REVIEW_CREATION_BEFORE_PLAN_END);
+        }
+    }
+
+    private ReviewCreateResponse storeReviewAndImages(User user, Plan plan, ReviewCreateRequest request, Review review) {
+
+        if (request.getFileUrls() != null && !request.getFileUrls().isEmpty()) {
+            List<String> imageList = imageStore.storeImageList(user, review.getId(), request.getFileUrls(), Image.EntityType.REVIEW);
+            return ReviewCreateResponse.fromEntityWithImage(plan, review, imageList);
+        }
+        return ReviewCreateResponse.fromEntity(plan, review);
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)

- 모임 생성 시 이미지를 배열 타입으로 받을 수 있도록 수정하였습니다.
- 모임 및 일정 상세 조회 시, 전체 일정 내 후기의 평균 평점 및 멤버 수 등의 데이터를 추가하였습니다.
- 모임 내 전체 일정 목록 조회 시, 동일 일정이 일정의 id 값만큼 중복 출력되는 문제를 해결하기 위해 `groupBy` 조건을 추가하였습니다.
- 모임 및 후기 관련 서비스 클래스에서 중복 로직을 제거하고, 공통으로 사용되는 메서드를 분리하여 리팩토링하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/meeting-detail-72 -> dev
- close #72 

<br/>

## 🔥 트러블 슈팅 (선택)
- 문제: 일정 목록 조회에서 동일 일정이 여러 번 출력되는 문제로 인해 쿼리 성능 저하가 발생했습니다.

  -> 해결: JPA의 `groupBy` 조건을 추가하여 중복을 제거하고, 쿼리 실행 속도를 최적화했습니다.
