### PR TITLE
[Chore] 배포 세팅

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -113,7 +113,7 @@ public class PlanController {
     public ResponseEntity<SuccessResponse<String>> cancelAttendance(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                     @PathVariable Long planId) {
 
-        return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(planService.cancelAttendance(userDetails.getUsername(), planId)));
+        return ResponseEntity.ok(SuccessResponse.successWithNoData(planService.cancelAttendance(userDetails.getUsername(), planId)));
     }
 
     @Operation(summary = "좋아요한 일정 목록 조회", description = "유저가 좋아요한 일정의 목록을 반환합니다.")

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -14,15 +14,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
       # 테이블명 설정
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-
+    show-sql: true
+    # SQL 문 포맷 설정
+    properties:
+      hibernate:
+        format_sql: true
   sql:
     init:
       data-locations: classpath:category.sql

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,15 +14,14 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-        format_sql: true
       # 테이블명 설정
       naming:
         physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-
+    show-sql: true
+    # SQL 문 포맷 설정
+    properties:
+      hibernate:
+        format_sql: true
   sql:
     init:
       data-locations: classpath:category.sql


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- application.yml 설정을 기존 설정으로 원복하였습니다.
- 일정 참여 취소 시 성공 응답 코드를 기존 201에서 200으로 수정하였습니다. (Delete 메서드이기 때문)

<br/>

## 🌱 반영 브랜치
- chore/prod-setting-32 -> dev
- close #

<br/>

## 🔥 트러블 슈팅 (선택)
- application.yml 의 DB 설정에서 수정한 설정에 의해 테이블명이 소문자 형태로 중복 생성되는 문제가 발생
- 그로 인해 데이터를 읽어오지 못하는 오류 발생
  -> 해결 : 기존 application.yml 의 네이밍 규칙 설정에 의해 테이블이 생성될 수 있도록 수정
