### PR TITLE
[Refactor] accessToken 전달 방법 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
 import com.wemo.backend.global.response.ErrorResponse;
 import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -37,8 +38,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             String method = request.getMethod(); // HTTP 메서드 가져오기
             log.info("요청 IP: {}, 요청 URI: {}", clientIp, requestURI);
 
-            String accessToken = jwtTokenProvider.resolveToken(request);
-            String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+            // 쿠키에서 토큰 읽기
+            String accessToken = getAccessTokenFromCookie(request);
+            String refreshToken = getRefreshTokenFromCookie(request);
 
             log.info("accessToken: {}, refreshToken : {}", accessToken, refreshToken);
 
@@ -48,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 return;
             }
 
-            if (requestURI.startsWith("/api/meetings") && "GET" .equalsIgnoreCase(method)) {
+            if (requestURI.startsWith("/api/meetings") && "GET".equalsIgnoreCase(method)) {
                 // 토큰이 없는 경우 비회원으로 처리
                 if (accessToken == null) {
                     filterChain.doFilter(request, response);
@@ -56,7 +58,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             }
 
-            if (requestURI.startsWith("/api/plans") && "GET" .equalsIgnoreCase(method)) {
+            if (requestURI.startsWith("/api/plans") && "GET".equalsIgnoreCase(method) && !requestURI.contains("like")) {
                 // 토큰이 없는 경우 비회원으로 처리
                 if (accessToken == null) {
                     filterChain.doFilter(request, response);
@@ -64,7 +66,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 }
             }
 
-            if (requestURI.startsWith("/api/reviews") && "GET" .equalsIgnoreCase(method)) {
+            if (requestURI.startsWith("/api/reviews") && "GET".equalsIgnoreCase(method)) {
                 // 토큰이 없는 경우 비회원으로 처리
                 if (accessToken == null) {
                     filterChain.doFilter(request, response);
@@ -73,7 +75,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             // 로그아웃 요청 처리
-            if ("/api/auths/signout" .equals(requestURI)) {
+            if ("/api/auths/signout".equals(requestURI)) {
                 if (!validateLogoutRequest(accessToken, refreshToken, response)) {
                     // 유효성 검증 실패 시 요청 중단
                     return;
@@ -171,6 +173,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 requestURI.startsWith("/login/oauth2/callback/kakao") ||
                 requestURI.startsWith("/login/oauth2/callback/google") ||
                 requestURI.startsWith("/login/oauth2/callback/naver");
+    }
+
+    // 쿠키에서 토큰 추출
+    private String getAccessTokenFromCookie(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    private String getRefreshTokenFromCookie(HttpServletRequest request) {
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("Refresh-Token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
@@ -10,7 +10,6 @@ import com.wemo.backend.domain.auth.token.entity.RefreshToken;
 import com.wemo.backend.domain.auth.token.service.JwtTokenUtils;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -30,37 +29,8 @@ public class JwtTokenProvider {
     private String JWT_SECRET;
 
     private final UserDetailsServiceImpl userDetailsService;
-    private static final String TOKEN_PREFIX = "Bearer "; // JWT 토큰의 접두사
     private final TokenBlacklistService tokenBlacklistService;
     private final RefreshTokenManager refreshTokenManager;
-
-    /**
-     * HTTP 요청에서 JWT accessToken 추출
-     *
-     * @param request HTTP 요청 객체
-     * @return JWT 토큰 문자열 반환
-     */
-    public String resolveToken(HttpServletRequest request) {
-
-        String bearerToken = request.getHeader("Authorization");
-
-        // Authorization 헤더가 존재하고, "Bearer "로 시작하는 경우 토큰 추출
-        if (bearerToken != null && bearerToken.startsWith(TOKEN_PREFIX)) {
-            return bearerToken.substring(TOKEN_PREFIX.length());
-        }
-        return null;
-    }
-
-    /**
-     * HTTP 요청에서 JWT refreshToken 추출
-     *
-     * @param request HTTP 요청 객체
-     * @return JWT 토큰 문자열 반환
-     */
-    public String resolveRefreshToken(HttpServletRequest request) {
-
-        return request.getHeader("Refresh-Token");
-    }
 
     /**
      * JWT accessToken 기반으로 인증 정보 생성
@@ -124,10 +94,6 @@ public class JwtTokenProvider {
      * @return 해당 토큰의 초기화된 만료시간 반환
      */
     public Long getExpiration(String accessToken) {
-        // accessToken이 'Bearer '로 시작하면 이를 제거
-        if (accessToken.startsWith("Bearer ")) {
-            accessToken = accessToken.substring(7);
-        }
 
         DecodedJWT jwt;
         JWTVerifier verifier = JWT

--- a/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
@@ -2,7 +2,6 @@ package com.wemo.backend.domain.auth;
 
 import com.wemo.backend.domain.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.http.HttpHeaders;
 
 public interface UserAuth {
 
@@ -10,6 +9,6 @@ public interface UserAuth {
 
     String saveRefreshTokenToRedis(User user);
 
-    HttpHeaders generateHeaderTokens(User user, HttpServletResponse response);
+    void generateHeaderTokens(User user, HttpServletResponse response);
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
@@ -1,12 +1,12 @@
 package com.wemo.backend.domain.auth;
 
+import com.wemo.backend.domain.auth.token.service.AccessTokenManager;
 import com.wemo.backend.domain.auth.token.service.JwtTokenUtils;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.user.entity.User;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -16,6 +16,7 @@ public class UserAuthImpl implements UserAuth {
 
     private final JwtTokenUtils jwtTokenUtils;
     private final RefreshTokenManager refreshTokenManager;
+    private final AccessTokenManager accessTokenManager;
 
     /**
      * Jwt accessToken 생성
@@ -46,22 +47,21 @@ public class UserAuthImpl implements UserAuth {
     }
 
     /**
-     * 응답 헤더에 accessToken, refreshToken 담아 반환
+     * 응답 쿠키에 accessToken, refreshToken 담아 반환
      *
      * @param user 유저 객체
-     * @return accessToken 담긴 헤더, refreshToken 은 쿠키로 전달
      */
     @Override
-    public HttpHeaders generateHeaderTokens(User user, HttpServletResponse response) {
+    public void generateHeaderTokens(User user, HttpServletResponse response) {
 
-        HttpHeaders headers = new HttpHeaders();
         String accessToken = getAccessToken(user);
         String refreshToken = saveRefreshTokenToRedis(user);
-        headers.set(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+
+        accessTokenManager.setAccessTokenInCookie(accessToken, response);
         refreshTokenManager.setRefreshTokenInCookie(refreshToken, response);
         log.info("accessToken 및 refreshToken 생성 완료");
         log.info("refreshToken 쿠키로 전달 완료");
-        return headers;
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
@@ -1,0 +1,28 @@
+package com.wemo.backend.domain.auth.token.service;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccessTokenManager {
+
+    /**
+     * accessToken 을 쿠키에 저장
+     *
+     * @param accessToken accessToken 값
+     */
+    public void setAccessTokenInCookie(String accessToken, HttpServletResponse response) {
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
+                .maxAge(5 * 60)
+                .sameSite("None")
+                .secure(true)
+                .httpOnly(true)
+                .path("/")
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -17,7 +17,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Optional;
 
 import static com.wemo.backend.global.exception.ErrorCode.ILLEGAL_REFRESH_TOKEN_NOT_VALID;
-import static org.springframework.http.HttpHeaders.AUTHORIZATION;
 
 @Slf4j
 @Component
@@ -26,6 +25,7 @@ public class RefreshTokenManager {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenUtils jwtTokenUtils;
+    private final AccessTokenManager accessTokenManager;
 
     /**
      * JWT refreshToken 생성 및 저장
@@ -78,10 +78,8 @@ public class RefreshTokenManager {
 
     /**
      * refreshToken 검증하고 새로운 토큰 생성 및 발급
-     *
-     * @return 새로 생성된 accessToken, refreshToken 담은 HttpHeaders
      */
-    public HttpHeaders reissueToken(HttpServletRequest request, HttpServletResponse response) {
+    public void reissueToken(HttpServletRequest request, HttpServletResponse response) {
 
         log.info("accessToken 재발급 요청 메서드 호출");
 
@@ -112,12 +110,10 @@ public class RefreshTokenManager {
         String newAccessToken = jwtTokenUtils.generateAccessToken(email);
         String newRefreshToken = jwtTokenUtils.generateRefreshToken(email);
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set(AUTHORIZATION, "Bearer " + newAccessToken);
+        accessTokenManager.setAccessTokenInCookie(newAccessToken, response);
         setRefreshTokenInCookie(newRefreshToken, response);
 
         log.info("토큰 생성 후 헤더에 담기 완료!");
-        return headers;
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/user/controller/TokenController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/TokenController.java
@@ -9,7 +9,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -30,8 +29,8 @@ public class TokenController {
     public ResponseEntity<SuccessResponse<String>> reissueToken(HttpServletRequest request,
                                                                 HttpServletResponse response) {
 
-        HttpHeaders httpHeaders = refreshTokenManager.reissueToken(request, response);
-        return ResponseEntity.status(200).headers(httpHeaders).body(SuccessResponse.successWithNoData("accessToken 재발급 성공"));
+        refreshTokenManager.reissueToken(request, response);
+        return ResponseEntity.ok(SuccessResponse.successWithNoData("accessToken 재발급 성공"));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
@@ -13,7 +13,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -62,8 +61,8 @@ public class UserController {
     @RequestMapping(value = "/signin", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> signin(@Valid @RequestBody SigninRequest request, HttpServletResponse response) {
 
-        HttpHeaders httpHeaders = userService.signin(request, response);
-        return ResponseEntity.status(200).headers(httpHeaders).body(SuccessResponse.successWithNoData("로그인 성공"));
+        userService.signin(request, response);
+        return ResponseEntity.ok(SuccessResponse.successWithNoData("로그인 성공"));
     }
 
     @Operation(summary = "로그아웃", description = "사용자가 로그아웃을 합니다.")

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -3,7 +3,6 @@ package com.wemo.backend.domain.user.service;
 import com.wemo.backend.domain.user.dto.*;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -13,7 +12,7 @@ public interface UserService {
 
     void signup(UserCreateRequest request);
 
-    HttpHeaders signin(SigninRequest request, HttpServletResponse response);
+    void signin(SigninRequest request, HttpServletResponse response);
 
     String signout(String accessToken, String refreshToken, HttpServletResponse response);
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -20,7 +20,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
-import org.springframework.http.HttpHeaders;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -75,17 +74,15 @@ public class UserServiceImpl implements UserService {
      * 로그인
      *
      * @param signinRequest 아이디, 비밀번호로 로그인
-     * @return 생성된 accessToken, refreshToken 담은 HttpHeaders
      */
     @Override
-    public HttpHeaders signin(SigninRequest signinRequest, HttpServletResponse response) {
+    public void signin(SigninRequest signinRequest, HttpServletResponse response) {
 
         // 유저 검증 및 객체 조회
         User user = userReader.getUserByEmail(signinRequest.getEmail());
         log.info("사용자 {} 로그인 성공", user.getEmail());
 
-        // accessToken 및 refreshToken 생성 후 전달
-        return userAuth.generateHeaderTokens(user, response);
+        userAuth.generateHeaderTokens(user, response);
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 프론트엔드의 SSR 적용을 위한 요청으로 기존 응답 헤더로 주고 받던 accessToken 방식을 쿠키로 수정하였습니다.
- 쿠키 만료 시간을 5분으로 설정하여 탈취당했을 때의 위험을 줄이고자 하였습니다.
- 필터에서 토큰 검증하는 방식을 수정하였습니다.
- 좋아요를 누른 일정 목록 조회 시 get 요청에 허용 경로로 포함되어 적절한 예외가 발생하지 않아 경로에 조건을 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- refactor/token-81 -> dev
- close #81 

<br/>
