### PR TITLE
[Refactor] 모임 후기 관련 응답 데이터 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -33,10 +33,10 @@ public class MeetingController {
                     content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "", method = RequestMethod.POST)
-    public ResponseEntity<SuccessResponse<String>> createMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                 @Valid @RequestBody MeetingCreateRequest request) {
-        meetingService.createMeeting(userDetails.getUsername(), request);
-        return ResponseEntity.status(201).body(SuccessResponse.successWithNoData("모임 생성 성공"));
+    public ResponseEntity<SuccessResponse<MeetingCreateResponse>> createMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                @Valid @RequestBody MeetingCreateRequest request) {
+
+        return ResponseEntity.status(201).body(SuccessResponse.success(meetingService.createMeeting(userDetails.getUsername(), request), "모임 생성 성공"));
     }
 
     @Operation(summary = "모임 가입", description = "모임에 가입합니다.")
@@ -48,6 +48,7 @@ public class MeetingController {
     @RequestMapping(value = "/{meetingId}", method = RequestMethod.POST)
     public ResponseEntity<SuccessResponse<String>> joinMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                @PathVariable Long meetingId) {
+
         return ResponseEntity.status(201).body(SuccessResponse.successWithNoData(meetingService.joinMeeting(userDetails.getUsername(), meetingId)));
     }
 
@@ -59,6 +60,7 @@ public class MeetingController {
     })
     @RequestMapping(value = "/{meetingId}", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<MeetingDetailResponse>> getMeetingDetail(@PathVariable Long meetingId) {
+
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getMeetingDetail(meetingId)));
     }
 
@@ -72,6 +74,7 @@ public class MeetingController {
     public ResponseEntity<SuccessResponse<String>> updateMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                  @PathVariable Long meetingId,
                                                                  @Valid @RequestBody MeetingUpdateRequest request) {
+
         return ResponseEntity.ok(SuccessResponse.successWithNoData(meetingService.updateMeeting(userDetails.getUsername(), meetingId, request)));
     }
 
@@ -84,6 +87,7 @@ public class MeetingController {
     @RequestMapping(value = "/{meetingId}", method = RequestMethod.DELETE)
     public ResponseEntity<SuccessResponse<String>> deleteMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                  @PathVariable Long meetingId) {
+
         return ResponseEntity.ok(SuccessResponse.successWithNoData(meetingService.deleteMeeting(userDetails.getUsername(), meetingId)));
     }
 
@@ -111,8 +115,8 @@ public class MeetingController {
     })
     @RequestMapping(value = "/{meetingId}/plans", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<MeetingPlanPagingResponse>> getPlanListByMeeting(@PathVariable Long meetingId,
-                                                                                               @RequestParam(defaultValue = "1") int page,
-                                                                                               @RequestParam(defaultValue = "10") int size) {
+                                                                                           @RequestParam(defaultValue = "1") int page,
+                                                                                           @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getPlanListByMeeting(meetingId, pageable)));
@@ -126,8 +130,8 @@ public class MeetingController {
     })
     @RequestMapping(value = "/{meetingId}/reviews", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<MeetingReviewPagingResponse>> getReviewListByMeeting(@PathVariable Long meetingId,
-                                                                                           @RequestParam(defaultValue = "1") int page,
-                                                                                           @RequestParam(defaultValue = "10") int size) {
+                                                                                               @RequestParam(defaultValue = "1") int page,
+                                                                                               @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getReviewListByMeeting(meetingId, pageable)));

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateResponse.java
@@ -1,0 +1,31 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class MeetingCreateResponse {
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String description;
+
+    private List<String> meetingImagePath;
+
+    public static MeetingCreateResponse fromEntity(Meeting meeting, List<String> meetingImagePath) {
+
+        return MeetingCreateResponse.builder()
+                .meetingId(meeting.getId())
+                .meetingName(meeting.getMeetingName())
+                .description(meeting.getDescription())
+                .meetingImagePath(meetingImagePath)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
@@ -25,6 +25,7 @@ public class MeetingDetailResponse {
     private String description;
 
     private String category;
+    private String email;
 
     private String nickname;
 
@@ -55,6 +56,7 @@ public class MeetingDetailResponse {
                 .memberCount(memberCount)
                 .description(meeting.getDescription())
                 .category(meeting.getCategory().getCategoryName())
+                .email(meeting.getUser().getEmail())
                 .nickname(meeting.getUser().getNickname())
                 .profileImagePath(meeting.getUser().getProfileImagePath())
                 .createdAt(meeting.getCreatedAt())

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 @Service
 public interface MeetingService {
 
-    void createMeeting(String email, MeetingCreateRequest request);
+    MeetingCreateResponse createMeeting(String email, MeetingCreateRequest request);
 
     String joinMeeting(String email, Long meetingId);
 

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -47,13 +47,16 @@ public class MeetingServiceImpl implements MeetingService {
      */
     @Override
     @Transactional
-    public void createMeeting(String email, MeetingCreateRequest request) {
+    public MeetingCreateResponse createMeeting(String email, MeetingCreateRequest request) {
 
         User user = validateUser(email);
         Meeting meeting = meetingStore.storeMeeting(request, user);
-        imageStore.storeImageList(user, meeting.getId(), request.getFileUrls(), Image.EntityType.MEETING);
+        List<String> meetingImagePath = imageStore.storeImageList(user, meeting.getId(), request.getFileUrls(), Image.EntityType.MEETING);
         meetingMemberStore.storeMemberToMeeting(user, meeting);
         log.info("사용자 {}의 모임 id {}가 생성되었습니다.", user.getEmail(), meeting.getId());
+
+        return MeetingCreateResponse.fromEntity(meeting, meetingImagePath);
+
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -29,10 +30,35 @@ public class ReviewListResponse {
 
     private String comment;
 
-    private String reviewImagePath;
+    private List<String> reviewImages;  // List<String> reviewImages 추가
 
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    // ReviewListResponse의 생성자를 추가하여 reviewImages 필드를 처리하도록 수정
+    public ReviewListResponse(Long planId, String planName, String planImagePath, String category, String address,
+                              String nickname, String profileImagePath, Long reviewId, int score, String comment,
+                              LocalDateTime createdAt, LocalDateTime updatedAt) {
+
+        this.planId = planId;
+        this.planName = planName;
+        this.planImagePath = planImagePath;
+        this.category = category;
+        this.address = address;
+        this.nickname = nickname;
+        this.profileImagePath = profileImagePath;
+        this.reviewId = reviewId;
+        this.score = score;
+        this.comment = comment;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
+    // reviewImages는 setter로 설정
+    public void setReviewImages(List<String> reviewImages) {
+
+        this.reviewImages = reviewImages;
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
@@ -59,14 +59,6 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                                 review.id,
                                 review.score,
                                 review.comment,
-                                Expressions.as(
-                                        select(image.fileUrl)
-                                                .from(image)
-                                                .where(image.entityId.eq(review.id),
-                                                        image.entityType.eq(Image.EntityType.REVIEW),
-                                                        image.main.eq(true)),
-                                        "reviewImagePath"
-                                ),
                                 review.createdAt,
                                 review.updatedAt
                         )
@@ -80,10 +72,22 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
         applyFilters(queryBuilder, province, district, startDate, endDate, categoryId, sort);
 
         // 페이징 적용
-        List<ReviewListResponse> reviewDetailInfoList = queryBuilder
+        List<ReviewListResponse> reviewList = queryBuilder
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
+
+        // 각 리뷰별로 이미지 목록을 별도로 처리
+        for (ReviewListResponse review : reviewList) {
+            List<String> reviewImageUrls = queryFactory
+                    .select(image.fileUrl)
+                    .from(image)
+                    .where(image.entityId.eq(review.getReviewId()), // reviewId로 이미지를 필터링
+                            image.entityType.eq(Image.EntityType.REVIEW))
+                    .fetch();
+
+            review.setReviewImages(reviewImageUrls); // 각 리뷰에 해당하는 이미지 목록 설정
+        }
 
         long total = Optional.ofNullable(
                 queryFactory
@@ -96,8 +100,7 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                         .fetchOne()
         ).orElse(0L);
 
-        return new PageImpl<>(reviewDetailInfoList, pageable, total);
-
+        return new PageImpl<>(reviewList, pageable, total);
     }
 
     // 필터링 적용

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserMeetingListResponse.java
@@ -15,6 +15,8 @@ public class UserMeetingListResponse {
 
     private String meetingName;
 
+    private String meetingImagePath;
+
     private String category;
 
     private Long memberCount;

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponse.java
@@ -12,6 +12,8 @@ public class UserPlanListResponse {
 
     private String nickname;
 
+    private String email;
+
     private String profileImagePath;
 
     private Long planId;
@@ -62,21 +64,25 @@ public class UserPlanListResponse {
 
     @JsonProperty("isCanceled")
     public boolean getIsCanceled() {
+
         return isCanceled;
     }
 
     @JsonProperty("isOpened")
     public boolean getIsOpened() {
+
         return isOpened;
     }
 
     @JsonProperty("isFulled")
     public boolean getIsFulled() {
+
         return isFulled;
     }
 
     @JsonProperty("isLiked")
     public boolean getIsLiked() {
+
         return isLiked;
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -53,6 +53,14 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 meeting.user.email,
                                 meeting.id,
                                 meeting.meetingName,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(meeting.id),
+                                                        image.entityType.eq(Image.EntityType.MEETING),
+                                                        image.main.eq(true)),
+                                        "meetingImagePath"
+                                ),
                                 meeting.category.categoryName,
                                 Expressions.as(
                                         JPAExpressions.select(meetingMember.count())
@@ -105,6 +113,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         Projections.constructor(
                                 UserPlanListResponse.class,
                                 user.nickname.as("nickname"),
+                                user.email.as("email"),
                                 user.profileImagePath.as("profileImage"),
                                 plan.id.as("planId"),
                                 plan.planName,

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -50,8 +50,8 @@ public class SecurityConfig {
 
                     CorsConfiguration configuration = new CorsConfiguration();
 
-                    configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
-                    configuration.setAllowedMethods(Collections.singletonList("*"));
+                    configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "https://we-mo-test.vercel.app"));
+                    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                     configuration.setAllowCredentials(true);
                     configuration.setAllowedHeaders(Collections.singletonList("*"));
                     configuration.setMaxAge(3600L);

--- a/src/main/java/com/wemo/backend/global/response/SuccessResponse.java
+++ b/src/main/java/com/wemo/backend/global/response/SuccessResponse.java
@@ -11,7 +11,7 @@ public class SuccessResponse<T> {
     private String message;
     private T data;
 
-    private static <T> SuccessResponse<T> success(T data, String message) {
+    public static <T> SuccessResponse<T> success(T data, String message) {
 
         return SuccessResponse.<T>builder()
                 .success(true)


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 생성 후 응답 데이터 반환되도록 수정
- 모임 상세 조회 시 유저 이메일 데이터 추가
- 내가 속한 모임 목록 조회 시 이미지 데이터 추가
- 후기 목록 조회 시 후기 이미지를 리스트 타입으로 수정

<br/>

## 🌱 반영 브랜치
- `refactor/add-data-83` -> `dev`
- close #83 

<br/>

## 🔥 트러블 슈팅 (선택)

### 문제 상황  
- 전체 후기 목록 조회 시 **QueryDSL**을 사용하고 있었으나, 기존 `String` 타입에서 `List<String>` 타입으로 데이터를 변경하는 과정에서 문제 발생

---

### 시도한 해결 방법 및 실패 원인  

1. **`Projections.fields()` 시도 → 실패**  
   - `Projections.fields()`를 사용하여 DTO에 필드를 직접 매핑하려 했으나, `List<String>` 타입의 필드를 매핑하는 데 실패  
   - **실패 원인:**  
     - `Projections.fields()`는 단순한 필드 매핑에 적합하지만, 컬렉션 타입(`List`)을 직접 지원하지 않음  
     - QueryDSL 버전에서 서브쿼리를 통한 리스트 필드 매핑이 정상적으로 동작하지 않음  
     - **컴파일 오류 발생**, 리스트 필드를 올바르게 매핑할 수 없었음

2. **`Expressions.list()` 시도 → 실패**  
   - `Expressions.list()`를 사용해 리스트 데이터를 쿼리에 포함하려 했으나, `Unsupported expression new List(com.querydsl.core.DefaultQueryMetadata@9e83ccdd)` 오류 발생  
   - **실패 원인:**  
     - QueryDSL에서 `Expressions.list()`는 단일 값 필드만 지원하고, 리스트 타입 필드 매핑이 지원되지 않음  
     - **컴파일은 성공했지만**, 실행 시 `ClassCastException` 발생  

---

### 최종 해결 방법  

- **`Projections.constructor()` + 수동 Setter 적용**  
  - QueryDSL의 `Projections.constructor()`를 사용하여 주요 필드를 매핑한 후,  
    리스트 타입 필드는 별도의 `setter` 메서드를 통해 추가  
  - 이 방식으로 DTO 생성 시 발생하는 타입 불일치 문제를 해결하고, 쿼리 실행 시 안정성을 확보

---

### 최종 해결 방법의 장점  

1. QueryDSL의 생성자 매핑을 활용하여 주요 필드를 정확하게 매핑  
2. 리스트 타입의 데이터를 추가적으로 처리하여 매핑의 유연성 확보  
3. 코드의 가독성과 유지보수성이 향상되고, 쿼리 성능 저하 방지  
