### PR TITLE
[Refactor] 소셜 로그인 데이터 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.oauth.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.wemo.backend.domain.auth.token.service.AccessTokenManager;
 import com.wemo.backend.domain.auth.token.service.JwtTokenUtils;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.user.entity.LoginType;
@@ -14,7 +15,6 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -34,6 +34,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     private final RefreshTokenManager refreshTokenManager;
     private final UserReader userReader;
     private final UserStore userStore;
+    private final AccessTokenManager accessTokenManager;
 
     @Value("${kakao.client.id}")
     private String kakaoClientId;
@@ -117,22 +118,23 @@ public class Oauth2ServiceImpl implements Oauth2Service {
         JsonNode userInfo = fetchUserInfo(accessToken, userInfoUrl);
         String email = extractUserInfo(userInfo, loginType, "email");
         String name = extractUserInfo(userInfo, loginType, "name");
-        String profileImageUrl = extractUserInfo(userInfo, loginType, "profile_image");
+        String nickname = extractUserInfo(userInfo, loginType, "nickname");
 
         // 유저 조회 또는 신규 등록
-        getUserByEmailOrRegister(email, name, profileImageUrl, loginType);
-
+        if (name.isEmpty() || name.isBlank()) {
+            getUserByEmailOrRegister(email, nickname, loginType);
+        } else if (nickname.isBlank() || nickname.isEmpty()) {
+            getUserByEmailOrRegister(email, name, loginType);
+        }
         // JWT 토큰 생성
         String jwtAccessToken = jwtTokenUtils.generateAccessToken(email);
         String jwtRefreshToken = refreshTokenManager.saveRefreshToken(email);
 
-        // 응답 헤더 설정
-        HttpHeaders responseHeaders = createResponseHeaders(jwtAccessToken);
-
-        // 쿠키에 refreshToken 추가
+        // 쿠키에 refreshToken, accessToken 추가
         refreshTokenManager.setRefreshTokenInCookie(jwtRefreshToken, response);
+        accessTokenManager.setAccessTokenInCookie(jwtAccessToken, response);
 
-        return buildResponseEntity(responseHeaders);
+        return buildResponseEntity();
     }
 
     private JsonNode fetchUserInfo(String accessToken, String userInfoUrl) {
@@ -148,37 +150,43 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     private String extractUserInfo(JsonNode userInfo, LoginType loginType, String field) {
 
         return switch (loginType) {
-            case KAKAO -> userInfo.path("kakao_account").path(field).asText();
+            case KAKAO -> {
+                if (field.equals("nickname")) {
+                    // nickname은 두 가지 위치에서 가져올 수 있음
+                    String nickname = userInfo.path("kakao_account").path("profile").path("nickname").asText();
+                    if (nickname.isEmpty()) {
+                        // `kakao_account.profile.nickname`이 비어있으면 `properties.nickname`으로 대체
+                        nickname = userInfo.path("properties").path("nickname").asText();
+                    }
+                    yield nickname;
+                } else {
+                    yield userInfo.path("kakao_account").path(field).asText();
+                }
+            }
             case GOOGLE -> userInfo.path(field).asText();
             case NAVER -> userInfo.path("response").path(field).asText();
             default -> throw new CustomException(ErrorCode.INVALID_LOGIN_TYPE);
         };
     }
 
-    private void getUserByEmailOrRegister(String email, String name, String profileImageUrl, LoginType loginType) {
+    private void getUserByEmailOrRegister(String email, String name, LoginType loginType) {
 
         User user;
         try {
             user = userReader.getUserByEmail(email);
         } catch (CustomException e) {
             log.info("신규 유저 저장: 추가 데이터 필요, email : {}", email);
-            String dummyPassword = "social_login"; // 기본값 설정
-            user = new User(email, name, profileImageUrl, loginType, "미제공", dummyPassword);
+
+            // 비밀번호는 null로 설정하고, isSocialLogin 플래그 추가
+            user = new User(email, name, loginType, "미제공", null, true);
+
             userStore.store(user);
         }
     }
 
-    private HttpHeaders createResponseHeaders(String accessToken) {
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Authorization", "Bearer " + accessToken);
-        return headers;
-    }
-
-    private ResponseEntity<SuccessResponse<Void>> buildResponseEntity(HttpHeaders headers) {
+    private ResponseEntity<SuccessResponse<Void>> buildResponseEntity() {
 
         return ResponseEntity.status(HttpStatus.OK)
-                .headers(headers)
                 .body(SuccessResponse.successWithNoData("로그인 성공"));
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/dto/SigninRequest.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/SigninRequest.java
@@ -11,6 +11,7 @@ public class SigninRequest {
     @Email(message = "이메일 형식이 올바르지 않습니다.")
     private String email;
 
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     private String password;
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserCreateRequest.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserCreateRequest.java
@@ -19,10 +19,13 @@ public class UserCreateRequest {
     @Size(min = 2, max = 20, message = "닉네임은 최소 2자, 최대 20자여야 합니다.")
     private String nickname;
 
+    @NotBlank(message = "회사명은 필수 입력 값입니다.")
     private String companyName;
 
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
     private String password;
 
+    @NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
     private String passwordCheck;
 
     public User createUser() {

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserInfoResponse.java
@@ -35,7 +35,7 @@ public class UserInfoResponse {
                 .nickname(user.getNickname())
                 .profileImagePath(user.getProfileImagePath())
                 .companyName(user.getCompanyName())
-                .loginType(user.getLoginType().getUserType())
+                .loginType(user.getLoginType().getLoginType())
                 .createdAt(user.getCreatedAt())
                 .joinedPlanCount(joinedPlanCount)
                 .likedPlanCount(likedPlanCount)

--- a/src/main/java/com/wemo/backend/domain/user/entity/LoginType.java
+++ b/src/main/java/com/wemo/backend/domain/user/entity/LoginType.java
@@ -12,6 +12,6 @@ public enum LoginType {
     GOOGLE("구글"),
     NAVER("네이버");
 
-    private final String userType;
+    private final String loginType;
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/entity/User.java
+++ b/src/main/java/com/wemo/backend/domain/user/entity/User.java
@@ -30,7 +30,7 @@ public class User extends Timestamped {
     @Comment("이메일")
     private String email;
 
-    @Column(name = "company_name")
+    @Column(name = "company_name", nullable = false)
     @Comment("회사명")
     private String companyName;
 
@@ -47,19 +47,24 @@ public class User extends Timestamped {
     private String profileImagePath;
 
     @Enumerated(value = EnumType.STRING)
-    @Column(name = "login_type")
+    @Column(name = "login_type", nullable = false)
+    @Comment("로그인 타입")
     @Builder.Default
     private LoginType loginType = LoginType.GENERAL;
 
-    public User(String email, String nickname, String profileImageUrl, LoginType loginType, String companyName, String password) {
+    @Column(name = "is_social_login", nullable = false)
+    @Comment("소셜 로그인 여부")
+    @Builder.Default
+    private boolean isSocialLogin = false;
+
+    public User(String email, String nickname, LoginType loginType, String companyName, String password, boolean isSocialLogin) {
 
         this.email = email;
         this.nickname = nickname;
-        this.profileImagePath = profileImageUrl;
         this.loginType = loginType;
         this.companyName = companyName;
         this.password = password;
-
+        this.isSocialLogin = isSocialLogin;
     }
 
     public User update(UserUpdateRequest request) {

--- a/src/main/java/com/wemo/backend/domain/user/service/UserStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserStoreImpl.java
@@ -23,14 +23,16 @@ public class UserStoreImpl implements UserStore {
     public void store(User initUser) {
 
         LoginType loginType = initUser.getLoginType() != null ? initUser.getLoginType() : LoginType.GENERAL;
+        String password = initUser.getPassword() != null ? initUser.getPassword() : "";
 
         User user = User.builder()
                 .email(initUser.getEmail())
                 .nickname(initUser.getNickname())
                 .companyName(initUser.getCompanyName())
-                .password(passwordEncoder.encode(initUser.getPassword()))
+                .password(passwordEncoder.encode(password))
                 .profileImagePath("https://ryungbucket.s3.ap-northeast-2.amazonaws.com/2480fdf5-c3ff-4348-82bf-b4daa4084ead.jpg")
                 .loginType(loginType)
+                .isSocialLogin(initUser.isSocialLogin())
                 .build();
 
         userRepository.save(user);


### PR DESCRIPTION
## 📌 작업 내용 (필수)

- 소셜 로그인 후 기존 응답 헤더로 발급되던 토큰을 **쿠키** 형태로 수정하였습니다.
- 카카오, 구글, 네이버의 데이터 컬럼명이 달라 이를 수정하여 올바른 데이터를 받아올 수 있도록 수정하였습니다.
- **User entity**에 소셜 로그인 여부를 판단하는 컬럼(`isSocialLogin`)을 추가하였습니다.  
  (추후 비밀번호 확인 및 수정 시에 사용할 예정입니다.)
- 소셜 로그인 시 **비밀번호를 따로 설정하지 않도록 수정**했고, 회원 가입 및 일반 로그인 시 비밀번호 유효성 검사를 추가하여 보안을 강화하였습니다.

<br/>

## 🌱 반영 브랜치

- `refactor/social-data-89` → `dev`
- close #89

<br/>

## 🔥 트러블 슈팅 (선택)

- 소셜 로그인에서 받아오는 데이터의 **컬럼명이 다르고 저장되어 있는 데이터 형태가 달랐**기에 일부 누락되는 데이터가 있었습니다.
- 각 플랫폼별 응답 데이터의 형태를 **로그로 확인**하고 수정하여 올바른 데이터가 저장되도록 수정하였습니다.
