### PR TITLE
[Refactor] 일정 상세 조회 시 유저 이메일 데이터 추가

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanDetailResponse.java
@@ -19,6 +19,8 @@ public class PlanDetailResponse {
 
     private String nickname;
 
+    private String email;
+
     private String profileImagePath;
 
     private String planName;
@@ -107,6 +109,7 @@ public class PlanDetailResponse {
         return PlanDetailResponse.builder()
                 .planId(plan.getId())
                 .nickname(plan.getUser().getNickname())
+                .email(plan.getUser().getEmail())
                 .profileImagePath(plan.getUser().getProfileImagePath())
                 .isJoined(isJoined)
                 .planName(plan.getPlanName())


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 상세 조회 시 해당 유저가 주최자인 경우 참여 취소 버튼을 누르지 못하도록 프론트에서 해당 여부를 확인할 수 있도록 유저 이메일 데이터를 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/plan-detail-92` -> `dev`
- close #92 

<br/>
