### PR TITLE
[Feat] 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -137,4 +137,17 @@ public class MeetingController {
         return ResponseEntity.ok(SuccessResponse.successWithData(meetingService.getReviewListByMeeting(meetingId, pageable)));
     }
 
+    @Operation(summary = "모임 목록 조회", description = "회원 또는 비회원이 요청하는 모임의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 모임 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingCursorPagingResponse>> getMeetingList(@RequestParam(required = false) Long cursor,
+                                                                                       @RequestParam(required = false, defaultValue = "10") int size,
+                                                                                       @RequestParam(required = false) Long categoryId) {
+
+        MeetingCursorPagingResponse response = meetingService.getMeetingList(cursor, size, categoryId);
+        return ResponseEntity.ok(SuccessResponse.successWithData(response));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCursorPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCursorPagingResponse.java
@@ -1,0 +1,26 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingCursorPagingResponse {
+
+    private int meetingCount;
+
+    private List<MeetingListResponse> meetingList;
+
+    private Long nextCursor;
+
+    public MeetingCursorPagingResponse(List<MeetingListResponse> meetingListResponses, int meetingCount) {
+
+        this.meetingCount = meetingCount;
+        this.meetingList = meetingListResponses;
+        this.nextCursor = meetingListResponses.isEmpty() ? null : meetingListResponses.get(meetingListResponses.size() - 1).getMeetingId();
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponse.java
@@ -1,0 +1,24 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MeetingListResponse {
+
+    private String email;
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String description;
+
+    private String meetingImagePath;
+
+    private Long memberCount;
+
+    private String category;
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.meeting.repository;
 
+import com.wemo.backend.domain.meeting.dto.MeetingCursorPagingResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
@@ -14,5 +15,7 @@ public interface MeetingQueryDsl {
     Page<MeetingPlanListResponse> getPlanListByMeeting(Meeting meeting, Pageable pageable);
 
     Page<MeetingReviewListResponse> getReviewListByMeeting(Meeting meeting, Pageable pageable);
+
+    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -1,10 +1,15 @@
 package com.wemo.backend.domain.meeting.repository;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.meeting.dto.MeetingCursorPagingResponse;
+import com.wemo.backend.domain.meeting.dto.MeetingListResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
 import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
 import com.wemo.backend.domain.meeting.entity.Meeting;
@@ -19,6 +24,7 @@ import java.util.Optional;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.meetingMember.entity.QMeetingMember.meetingMember;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
 import static com.wemo.backend.domain.review.entity.QReview.review;
@@ -164,6 +170,76 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
         ).orElse(0L);
 
         return new PageImpl<>(reviewListResponses, pageable, total);
+    }
+
+    @Override
+    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId) {
+
+        BooleanBuilder listConditions = new BooleanBuilder();
+        if (cursor != null) {
+            listConditions.and(meeting.id.lt(cursor));
+        }
+
+        List<MeetingListResponse> meetingListResponses = queryFactory
+                .select(
+                        Projections.constructor(
+                                MeetingListResponse.class,
+                                user.email,
+                                meeting.id,
+                                meeting.meetingName,
+                                meeting.description,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(meeting.id),
+                                                        image.entityType.eq(Image.EntityType.MEETING),
+                                                        image.main.eq(true)),
+                                        "meetingImagePath"
+                                ),
+                                Expressions.as(
+                                        JPAExpressions.select(meetingMember.count())
+                                                .from(meetingMember)
+                                                .where(meetingMember.meeting.id.eq(meeting.id)
+                                                        .and(meetingMember.deletedAt.isNull())),
+                                        "memberCount"
+                                ),
+                                meeting.category.categoryName
+                        )
+                )
+                .from(meeting)
+                .leftJoin(meeting.user, user)
+                .where(listConditions)
+                .where(buildFilterConditions(categoryId))
+                .where(meeting.deletedAt.isNull())
+                .orderBy(meeting.createdAt.desc())
+                .limit(size)
+                .stream().toList();
+
+        long meetingCount = Optional.ofNullable(
+                queryFactory
+                        .select(meeting.count())
+                        .from(meeting)
+                        .where(buildFilterConditions(categoryId))
+                        .where(meeting.deletedAt.isNull())
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new MeetingCursorPagingResponse(meetingListResponses, (int) meetingCount);
+    }
+
+    private BooleanExpression buildFilterConditions(Long categoryId) {
+
+        BooleanExpression condition = meeting.deletedAt.isNull();
+
+        if (categoryId != null) {
+            if (categoryId == 1) {
+                condition = condition.and(meeting.category.parentId.eq(categoryId));
+            } else {
+                condition = condition.and(meeting.category.id.eq(categoryId));
+            }
+        }
+
+        return condition;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -23,4 +23,6 @@ public interface MeetingService {
 
     MeetingReviewPagingResponse getReviewListByMeeting(Long meetingId, Pageable pageable);
 
+    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -206,6 +206,21 @@ public class MeetingServiceImpl implements MeetingService {
         return new MeetingReviewPagingResponse(meeting, meetingRepository.getReviewListByMeeting(meeting, pageable));
     }
 
+    /**
+     * 모임 목록 조회
+     * - 커서 기반 페이징 처리된 모임 목록 반환
+     *
+     * @param cursor     커서 id
+     * @param size       데이터 개수
+     * @param categoryId 카테고리 id
+     * @return 요청 조건에 알맞은 모임 목록
+     */
+    @Override
+    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId) {
+
+        return meetingRepository.getMeetingList(cursor, size, categoryId);
+    }
+
     // 유틸리티 메서드들
 
     /**

--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -62,16 +62,16 @@ public class PlanController {
             @ApiResponse(responseCode = "200", description = "요청한 일정 목록이 반환되었습니다.")
     })
     @RequestMapping(value = "", method = RequestMethod.GET)
-    public ResponseEntity<SuccessResponse<PlanCursorPagingResponse>> getGatherings(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                                   @RequestParam(required = false) Long cursor, // 커서 파라미터 추가
-                                                                                   @RequestParam(required = false, defaultValue = "10") int size,
-                                                                                   @RequestParam(required = false) String query,
-                                                                                   @RequestParam(required = false) String province,
-                                                                                   @RequestParam(required = false) String district,
-                                                                                   @RequestParam(required = false) String startDate,
-                                                                                   @RequestParam(required = false) String endDate,
-                                                                                   @RequestParam(required = false) Long categoryId,
-                                                                                   @RequestParam(required = false) String sort) {
+    public ResponseEntity<SuccessResponse<PlanCursorPagingResponse>> getPlanList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                 @RequestParam(required = false) Long cursor,
+                                                                                 @RequestParam(required = false, defaultValue = "10") int size,
+                                                                                 @RequestParam(required = false) String query,
+                                                                                 @RequestParam(required = false) String province,
+                                                                                 @RequestParam(required = false) String district,
+                                                                                 @RequestParam(required = false) String startDate,
+                                                                                 @RequestParam(required = false) String endDate,
+                                                                                 @RequestParam(required = false) Long categoryId,
+                                                                                 @RequestParam(required = false) String sort) {
 
         PlanCursorPagingResponse response = planService.getPlanList(userDetails, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -171,7 +171,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                                                                 : likes.user.email.isNull()
                                                 )
                                 ).gt(0L),
-                        "islikesd")
+                        "isLiked")
         );
     }
 

--- a/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/review/dto/ReviewListResponse.java
@@ -10,20 +10,6 @@ import java.util.List;
 @AllArgsConstructor
 public class ReviewListResponse {
 
-    private Long planId;
-
-    private String planName;
-
-    private String planImagePath;
-
-    private String category;
-
-    private String address;
-
-    private String nickname;
-
-    private String profileImagePath;
-
     private Long reviewId;
 
     private int score;
@@ -36,23 +22,38 @@ public class ReviewListResponse {
 
     private LocalDateTime updatedAt;
 
-    // ReviewListResponse의 생성자를 추가하여 reviewImages 필드를 처리하도록 수정
-    public ReviewListResponse(Long planId, String planName, String planImagePath, String category, String address,
-                              String nickname, String profileImagePath, Long reviewId, int score, String comment,
-                              LocalDateTime createdAt, LocalDateTime updatedAt) {
+    private String nickname;
 
-        this.planId = planId;
-        this.planName = planName;
-        this.planImagePath = planImagePath;
-        this.category = category;
-        this.address = address;
-        this.nickname = nickname;
-        this.profileImagePath = profileImagePath;
+    private String profileImagePath;
+
+    private Long planId;
+
+    private String planName;
+
+    private String planImagePath;
+
+    private String category;
+
+    private String address;
+
+    // ReviewListResponse의 생성자를 추가하여 reviewImages 필드를 처리하도록 수정
+    public ReviewListResponse(Long reviewId, int score, String comment, LocalDateTime createdAt, LocalDateTime updatedAt,
+                              String nickname, String profileImagePath, Long planId, String planName,
+                              String planImagePath, String category, String address) {
+
         this.reviewId = reviewId;
         this.score = score;
         this.comment = comment;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+        this.nickname = nickname;
+        this.profileImagePath = profileImagePath;
+        this.planId = planId;
+        this.planName = planName;
+        this.planImagePath = planImagePath;
+        this.category = category;
+        this.address = address;
+
     }
 
     // reviewImages는 setter로 설정

--- a/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/querydsl/ReviewQueryDslImpl.java
@@ -42,6 +42,13 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                 .select(
                         Projections.constructor(
                                 ReviewListResponse.class,
+                                review.id,
+                                review.score,
+                                review.comment,
+                                review.createdAt,
+                                review.updatedAt,
+                                user.nickname,
+                                user.profileImagePath,
                                 plan.id,
                                 plan.planName,
                                 Expressions.as(
@@ -53,14 +60,7 @@ public class ReviewQueryDslImpl implements ReviewQueryDsl {
                                         "planImagePath"
                                 ),
                                 plan.meeting.category.categoryName,
-                                plan.address,
-                                user.nickname,
-                                user.profileImagePath,
-                                review.id,
-                                review.score,
-                                review.comment,
-                                review.createdAt,
-                                review.updatedAt
+                                plan.address
                         )
                 )
                 .from(review)

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
@@ -11,14 +11,6 @@ public class UserReviewListResponse {
 
     private Long reviewId;
 
-    private String planName;
-
-    private LocalDateTime dateTime;
-
-    private String category;
-
-    private String address;
-
     private int score;
 
     private String comment;
@@ -28,5 +20,15 @@ public class UserReviewListResponse {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
+
+    private Long planId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private String category;
+
+    private String address;
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -228,10 +228,6 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         Projections.constructor(
                                 UserReviewListResponse.class,
                                 review.id,
-                                review.plan.planName,
-                                review.plan.dateTime,
-                                category.categoryName,
-                                review.plan.address,
                                 review.score,
                                 review.comment,
                                 Expressions.as(
@@ -243,7 +239,12 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                         "reviewImagePath"
                                 ),
                                 review.createdAt,
-                                review.updatedAt
+                                review.updatedAt,
+                                review.plan.id,
+                                review.plan.planName,
+                                review.plan.dateTime,
+                                category.categoryName,
+                                review.plan.address
                         )
                 )
                 .from(review)
@@ -254,6 +255,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .and(image.entityType.eq(Image.EntityType.REVIEW)))
                 .where(review.user.email.eq(email)) // 유저가 작성한 후기만
                 .where(review.plan.meeting.deletedAt.isNull())
+                .groupBy(review.id)
                 .orderBy(review.createdAt.desc());
 
         List<UserReviewListResponse> reviewListResponses = queryBuilder


### PR DESCRIPTION
## 📌 작업 내용 (필수)
### 수정한 내용
- 내가 작성한 후기 목록 조회 시 planId 값 추가하였고, 중복 조회 방지를 위해 groupBy 설정을 추가하였습니다.
- 후기 목록 조회 시 데이터 반환 형태 수정하였습니다. (추후 각 정보별로 그룹지어 표현하면 가독성이 좋을 수 있겠다는 생각을 했습니다.)
- 일정 목록 조회 시 오타 수정하였습니다.

### 추가한 내용
- 모임 목록 조회 기능 구현하였습니다.
- 커서 기반 페이지 네이션으로 구현하였고 카테고리별 필터링이 가능합니다.

<br/>

## 🌱 반영 브랜치
- `feat/meeting-list-77` -> `dev`
- close #77 

<br/>
