### PR TITLE
[Refactor] 모임 목록 조회 시 멤버 수 기준 정렬 조건 추가

### DIFF
--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -144,9 +144,10 @@ public class MeetingController {
     @RequestMapping(value = "", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<MeetingCursorPagingResponse>> getMeetingList(@RequestParam(required = false) Long cursor,
                                                                                        @RequestParam(required = false, defaultValue = "10") int size,
-                                                                                       @RequestParam(required = false) Long categoryId) {
+                                                                                       @RequestParam(required = false) Long categoryId,
+                                                                                       @RequestParam(required = false) String sort) {
 
-        MeetingCursorPagingResponse response = meetingService.getMeetingList(cursor, size, categoryId);
+        MeetingCursorPagingResponse response = meetingService.getMeetingList(cursor, size, categoryId, sort);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -16,6 +16,6 @@ public interface MeetingQueryDsl {
 
     Page<MeetingReviewListResponse> getReviewListByMeeting(Meeting meeting, Pageable pageable);
 
-    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId);
+    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId, String sort);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.meeting.repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -173,7 +174,7 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
     }
 
     @Override
-    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId) {
+    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId, String sort) {
 
         BooleanBuilder listConditions = new BooleanBuilder();
         if (cursor != null) {
@@ -211,9 +212,12 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                 .where(listConditions)
                 .where(buildFilterConditions(categoryId))
                 .where(meeting.deletedAt.isNull())
-                .orderBy(meeting.createdAt.desc())
+                .orderBy(
+                        getOrderSpecifier(sort),  // memberCount 정렬 기준
+                        meeting.createdAt.desc()  // createdAt 정렬 기준
+                )
                 .limit(size)
-                .stream().toList();
+                .fetch();  // .stream().toList()를 .fetch()로 수정
 
         long meetingCount = Optional.ofNullable(
                 queryFactory
@@ -240,6 +244,17 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
         }
 
         return condition;
+    }
+
+    // 정렬 조건 적용 함수
+    private OrderSpecifier<?> getOrderSpecifier(String sort) {
+
+        if ("memberDesc".equals(sort)) {
+            return Expressions.numberTemplate(Long.class,
+                    "(select count(*) from MeetingMember mm where mm.meeting.id = {0} and mm.deletedAt is null)",
+                    meeting.id).desc();
+        }
+        return meeting.createdAt.desc(); // 기본 최신순 정렬
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -23,7 +23,7 @@ public interface MeetingService {
 
     MeetingReviewPagingResponse getReviewListByMeeting(Long meetingId, Pageable pageable);
 
-    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId);
+    MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId, String sort);
 
     String joinCancelMeeting(String email, Long meetingId);
 

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -213,12 +213,13 @@ public class MeetingServiceImpl implements MeetingService {
      * @param cursor     커서 id
      * @param size       데이터 개수
      * @param categoryId 카테고리 id
+     * @param sort       정렬 기준
      * @return 요청 조건에 알맞은 모임 목록
      */
     @Override
-    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId) {
+    public MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId, String sort) {
 
-        return meetingRepository.getMeetingList(cursor, size, categoryId);
+        return meetingRepository.getMeetingList(cursor, size, categoryId, sort);
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 목록 조회 시 멤버 수 기준 정렬 조건 추가하였습니다.
- sort 값은 선택이며 모임의 멤버 수가 같은 경우 최신 순으로 반환되도록 하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/meeting-list-101` -> `dev`
- close #101 

<br/>

## 🔥 트러블 슈팅 (선택)

- **문제 1**: 멤버 수 데이터를 따로 관리하지 않고 동적으로 계산하여 반환하고 있었음. 그러나 QueryDSL에서 `JPAExpressions.select()` 같은 서브쿼리는 `orderBy()`에서 바로 사용할 수 없어 멤버 수 기준으로 정렬하는 데 문제 발생  
  - **해결 방법**: 서브쿼리 결과를 `orderBy()`에서 사용할 수 있도록 쿼리문을 추가로 작성하여 멤버 수 기준 정렬 조건 추가. `JPAExpressions.select()` 사용하여 멤버 수 계산하고, `Expressions.numberTemplate`으로 정렬 기준에 반영

- **문제 2**: 멤버 수가 같은 경우 최신 순으로 정렬해야 했는데, `orderBy()`에서 정렬 조건 추가 시 `SemanticException` 오류 발생  
  - **해결 방법**: `orderBy`에 조건 추가하여 `memberCount` 기준으로 먼저 정렬하고, 멤버 수가 같을 경우 `createdAt` 기준으로 최신 순으로 정렬. `stream.toList()`를 `fetch()`로 수정하여 `QueryDSL`의 결과를 올바르게 반환
