### PR TITLE
[Refactor] 내 모임 및 일정 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -34,6 +34,19 @@ public class UserDashboardController {
             @ApiResponse(responseCode = "200", description = "내가 속한 모임 목록이 반환되었습니다.")
     })
     @RequestMapping(value = "/meetings", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserMeetingPagingResponse>> getMeetingList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                     @RequestParam(defaultValue = "1") int page,
+                                                                                     @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMeetingList(userDetails.getUsername(), pageable)));
+    }
+
+    @Operation(summary = "내가 만든 모임 목록 조회", description = "유저가 만든 모임의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 만든 모임 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/meetings/me", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<UserMeetingPagingResponse>> getMyMeetingList(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                                        @RequestParam(defaultValue = "1") int page,
                                                                                        @RequestParam(defaultValue = "10") int size) {
@@ -41,7 +54,6 @@ public class UserDashboardController {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
         return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyMeetingList(userDetails.getUsername(), pageable)));
     }
-
 
     @Operation(summary = "내 일정 목록 조회", description = "유저가 참여한 일정의 목록을 반환합니다.")
     @ApiResponses(value = {
@@ -79,8 +91,8 @@ public class UserDashboardController {
     })
     @RequestMapping(value = "/reviews/available", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getPlanListReviewAvailable(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                                 @RequestParam(defaultValue = "1") int page,
-                                                                                 @RequestParam(defaultValue = "10") int size) {
+                                                                                              @RequestParam(defaultValue = "1") int page,
+                                                                                              @RequestParam(defaultValue = "10") int size) {
 
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
 

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -60,6 +60,21 @@ public class UserDashboardController {
             @ApiResponse(responseCode = "200", description = "내가 참여한 일정의 목록이 반환되었습니다.")
     })
     @RequestMapping(value = "/plans", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getPlanList(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                               @RequestParam(defaultValue = "1") int page,
+                                                                               @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getPlanList(userDetails.getUsername(), pageable)));
+
+    }
+
+    @Operation(summary = "내가 만든 일정 목록 조회", description = "유저가 만든 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 만든 일정의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/plans/me", method = RequestMethod.GET)
     public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getMyPlanList(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                                  @RequestParam(defaultValue = "1") int page,
                                                                                  @RequestParam(defaultValue = "10") int size) {

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -15,6 +15,8 @@ public interface UserQueryDsl {
 
     Page<UserPlanListResponse> getUserPlanList(String email, Pageable pageable);
 
+    Page<UserPlanListResponse> getMyPlanList(String email, Pageable pageable);
+
     Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable);
 
     Page<UserPlanReviewableListResponse> getUserPlanListReviewAvailable(String email, Pageable pageable);

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -11,6 +11,8 @@ public interface UserQueryDsl {
 
     Page<UserMeetingListResponse> getUserMeetingList(String email, Pageable pageable);
 
+    Page<UserMeetingListResponse> getMyMeetingList(String email, Pageable pageable);
+
     Page<UserPlanListResponse> getUserPlanList(String email, Pageable pageable);
 
     Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable);

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -249,7 +249,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                                                                 : likes.user.email.isNull()
                                                                 )
                                                 ).gt(0L),
-                                        "islikesd")
+                                        "isLiked")
                         )
                 )
                 .from(plan)
@@ -257,6 +257,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
                 .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
                 .where(plan.meeting.deletedAt.isNull())
+                .where(plan.user.email.ne(email)) // 유저가 만들지 않은 일정
                 .orderBy(plan.createdAt.desc());
 
         // 페이징 처리
@@ -273,6 +274,126 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .leftJoin(attendance).on(attendance.plan.eq(plan))
                         .where(attendance.user.email.eq(email))
                         .where(plan.meeting.deletedAt.isNull())
+                        .where(plan.user.email.ne(email))
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(planListResponses, pageable, total);
+
+    }
+
+    @Override
+    public Page<UserPlanListResponse> getMyPlanList(String email, Pageable pageable) {
+
+        updateIsFulledStatus();
+
+        JPAQuery<UserPlanListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserPlanListResponse.class,
+                                user.nickname.as("nickname"),
+                                user.email.as("email"),
+                                user.profileImagePath.as("profileImage"),
+                                plan.id.as("planId"),
+                                plan.planName,
+                                Expressions.as(
+                                        queryFactory.select(meeting.category.categoryName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "category"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.id)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingId"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.meetingName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingName"
+                                ),
+                                plan.address,
+                                Expressions.as(
+                                        queryFactory.select(province.provinceName)
+                                                .from(province)
+                                                .where(plan.district.province.id.eq(province.id)),
+                                        "province"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(district.districtName)
+                                                .from(district)
+                                                .where(plan.district.id.eq(district.id)),
+                                        "district"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
+                                        "planImagePath"
+                                ),
+                                plan.dateTime,
+                                plan.registrationEnd,
+                                plan.capacity,
+                                Expressions.as(
+                                        queryFactory.select(attendance.count())
+                                                .from(attendance)
+                                                .where(attendance.plan.id.eq(plan.id)
+                                                        .and(attendance.deletedAt.isNull())),
+                                        "participants"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(likes.plan.id.eq(plan.id)),
+                                        "likesCount"
+                                ),
+                                plan.viewCount,
+                                plan.createdAt,
+                                plan.updatedAt,
+                                plan.opened,
+                                plan.canceled,
+                                plan.fulled,
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(
+                                                        likes.plan.id.eq(plan.id)
+                                                                .and(
+                                                                        email != null
+                                                                                ? likes.user.email.eq(email)
+                                                                                : likes.user.email.isNull()
+                                                                )
+                                                ).gt(0L),
+                                        "isLiked")
+                        )
+                )
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .leftJoin(attendance).on(attendance.plan.eq(plan))
+                .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
+                .where(plan.meeting.deletedAt.isNull())
+                .where(plan.user.email.eq(email)) // 유저가 만든 일정
+                .orderBy(plan.createdAt.desc());
+
+        // 페이징 처리
+        List<UserPlanListResponse> planListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 총 개수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(plan.count())
+                        .from(plan)
+                        .leftJoin(attendance).on(attendance.plan.eq(plan))
+                        .where(attendance.user.email.eq(email))
+                        .where(plan.meeting.deletedAt.isNull())
+                        .where(plan.user.email.eq(email))
                         .fetchOne()
         ).orElse(0L);
 

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.user.repository.querydsl;
 
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
@@ -18,6 +19,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
@@ -45,69 +47,26 @@ public class UserQueryDslImpl implements UserQueryDsl {
     @Override
     public Page<UserMeetingListResponse> getUserMeetingList(String email, Pageable pageable) {
 
-        // 메인 쿼리
-        JPAQuery<UserMeetingListResponse> queryBuilder = queryFactory
-                .select(
-                        Projections.constructor(
-                                UserMeetingListResponse.class,
-                                meeting.user.email,
-                                meeting.id,
-                                meeting.meetingName,
-                                Expressions.as(
-                                        queryFactory.select(image.fileUrl)
-                                                .from(image)
-                                                .where(image.entityId.eq(meeting.id),
-                                                        image.entityType.eq(Image.EntityType.MEETING),
-                                                        image.main.eq(true)),
-                                        "meetingImagePath"
-                                ),
-                                meeting.category.categoryName,
-                                Expressions.as(
-                                        JPAExpressions.select(meetingMember.count())
-                                                .from(meetingMember)
-                                                .where(meetingMember.meeting.id.eq(meeting.id)
-                                                        .and(meetingMember.deletedAt.isNull())),
-                                        "memberCount"
-                                ),
-                                meeting.createdAt,
-                                meeting.updatedAt
-                        )
-                )
-                .from(meeting)
-                .leftJoin(meeting.user, user)
-                .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                .where(meetingMember.user.email.eq(email)) // 유저가 가입한 모임
-                .where(meeting.user.email.ne(email)) // 유저가 만든 모임이 아닌 경우
-                .where(meeting.deletedAt.isNull())
-                .groupBy(meeting.id) // 그룹화
-                .orderBy(meeting.createdAt.desc());
-
-        // 페이징 처리
-        List<UserMeetingListResponse> userMeetingListResponses = queryBuilder
-                .limit(pageable.getPageSize())
-                .offset(pageable.getOffset())
-                .fetch();
-
-        // 총 개수 조회
-        long total = Optional.ofNullable(
-                queryFactory
-                        .select(meeting.count())
-                        .from(meeting)
-                        .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                        .where(meetingMember.user.email.eq(email)) // 유저가 가입한 모임
-                        .where(meeting.user.email.ne(email)) // 유저가 만든 모임이 아닌 경우
-                        .where(meeting.deletedAt.isNull())
-                        .fetchOne()
-        ).orElse(0L);
-
-        return new PageImpl<>(userMeetingListResponses, pageable, total);
+        return getMeetingList(email, pageable, false);
     }
 
-    @Override
     public Page<UserMeetingListResponse> getMyMeetingList(String email, Pageable pageable) {
 
-        // 메인 쿼리
-        JPAQuery<UserMeetingListResponse> queryBuilder = queryFactory
+        return getMeetingList(email, pageable, true);
+    }
+
+    private Page<UserMeetingListResponse> getMeetingList(String email, Pageable pageable, boolean isMyMeeting) {
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(meeting.deletedAt.isNull());
+        whereClause.and(user.email.eq(email)); // ✅ user를 기준으로 필터링
+        if (isMyMeeting) {
+            whereClause.and(meeting.user.email.eq(email)); // ✅ 내가 만든 모임 조회
+        } else {
+            whereClause.and(meeting.user.email.ne(email)); // ✅ 가입된 모임 중 내가 만든 모임 제외
+        }
+
+        List<UserMeetingListResponse> results = queryFactory
                 .select(
                         Projections.constructor(
                                 UserMeetingListResponse.class,
@@ -134,160 +93,51 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 meeting.updatedAt
                         )
                 )
-                .from(meeting)
-                .leftJoin(meeting.user, user)
-                .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                .where(meeting.user.email.eq(email)) // 유저가 작성한 모임
-                .where(meeting.deletedAt.isNull())
+                .from(meetingMember)  // ✅ meetingMember 기준 조회
+                .join(meetingMember.meeting, meeting)  // ✅ meetingMember → meeting Join
+                .join(meetingMember.user, user)  // ✅ meetingMember → user Join
+                .where(whereClause)
                 .groupBy(meeting.id) // 그룹화
-                .orderBy(meeting.createdAt.desc());
-
-        // 페이징 처리
-        List<UserMeetingListResponse> userMeetingListResponses = queryBuilder
-                .limit(pageable.getPageSize())
+                .orderBy(meeting.createdAt.desc())
                 .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
-        // 총 개수 조회
-        long total = Optional.ofNullable(
-                queryFactory
-                        .select(meeting.count())
-                        .from(meeting)
-                        .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                        .where(meeting.user.email.eq(email)) // 유저가 작성한 모임
-                        .where(meeting.deletedAt.isNull())
-                        .fetchOne()
-        ).orElse(0L);
+        long total = Objects.requireNonNullElse(
+                queryFactory.select(meeting.count())
+                        .from(meetingMember)
+                        .join(meetingMember.meeting, meeting)
+                        .join(meetingMember.user, user)
+                        .where(whereClause)
+                        .fetchOne(), 0L
+        );
 
-        return new PageImpl<>(userMeetingListResponses, pageable, total);
-
+        return new PageImpl<>(results, pageable, total);
     }
 
-    @Override
     public Page<UserPlanListResponse> getUserPlanList(String email, Pageable pageable) {
 
-        updateIsFulledStatus();
-
-        JPAQuery<UserPlanListResponse> queryBuilder = queryFactory
-                .select(
-                        Projections.constructor(
-                                UserPlanListResponse.class,
-                                user.nickname.as("nickname"),
-                                user.email.as("email"),
-                                user.profileImagePath.as("profileImage"),
-                                plan.id.as("planId"),
-                                plan.planName,
-                                Expressions.as(
-                                        queryFactory.select(meeting.category.categoryName)
-                                                .from(meeting)
-                                                .where(meeting.id.eq(plan.meeting.id)),
-                                        "category"
-                                ),
-                                Expressions.as(
-                                        queryFactory.select(meeting.id)
-                                                .from(meeting)
-                                                .where(meeting.id.eq(plan.meeting.id)),
-                                        "meetingId"
-                                ),
-                                Expressions.as(
-                                        queryFactory.select(meeting.meetingName)
-                                                .from(meeting)
-                                                .where(meeting.id.eq(plan.meeting.id)),
-                                        "meetingName"
-                                ),
-                                plan.address,
-                                Expressions.as(
-                                        queryFactory.select(province.provinceName)
-                                                .from(province)
-                                                .where(plan.district.province.id.eq(province.id)),
-                                        "province"
-                                ),
-                                Expressions.as(
-                                        queryFactory.select(district.districtName)
-                                                .from(district)
-                                                .where(plan.district.id.eq(district.id)),
-                                        "district"
-                                ),
-                                Expressions.as(
-                                        queryFactory.select(image.fileUrl)
-                                                .from(image)
-                                                .where(image.entityId.eq(plan.id),
-                                                        image.entityType.eq(Image.EntityType.PLAN),
-                                                        image.main.eq(true)),
-                                        "planImagePath"
-                                ),
-                                plan.dateTime,
-                                plan.registrationEnd,
-                                plan.capacity,
-                                Expressions.as(
-                                        queryFactory.select(attendance.count())
-                                                .from(attendance)
-                                                .where(attendance.plan.id.eq(plan.id)
-                                                        .and(attendance.deletedAt.isNull())),
-                                        "participants"
-                                ),
-                                Expressions.as(
-                                        queryFactory.select(likes.count())
-                                                .from(likes)
-                                                .where(likes.plan.id.eq(plan.id)),
-                                        "likesCount"
-                                ),
-                                plan.viewCount,
-                                plan.createdAt,
-                                plan.updatedAt,
-                                plan.opened,
-                                plan.canceled,
-                                plan.fulled,
-                                Expressions.as(
-                                        queryFactory.select(likes.count())
-                                                .from(likes)
-                                                .where(
-                                                        likes.plan.id.eq(plan.id)
-                                                                .and(
-                                                                        email != null
-                                                                                ? likes.user.email.eq(email)
-                                                                                : likes.user.email.isNull()
-                                                                )
-                                                ).gt(0L),
-                                        "isLiked")
-                        )
-                )
-                .from(plan)
-                .leftJoin(plan.user, user)
-                .leftJoin(attendance).on(attendance.plan.eq(plan))
-                .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
-                .where(plan.meeting.deletedAt.isNull())
-                .where(plan.user.email.ne(email)) // 유저가 만들지 않은 일정
-                .orderBy(plan.createdAt.desc());
-
-        // 페이징 처리
-        List<UserPlanListResponse> planListResponses = queryBuilder
-                .limit(pageable.getPageSize())
-                .offset(pageable.getOffset())
-                .fetch();
-
-        // 총 개수 조회
-        long total = Optional.ofNullable(
-                queryFactory
-                        .select(plan.count())
-                        .from(plan)
-                        .leftJoin(attendance).on(attendance.plan.eq(plan))
-                        .where(attendance.user.email.eq(email))
-                        .where(plan.meeting.deletedAt.isNull())
-                        .where(plan.user.email.ne(email))
-                        .fetchOne()
-        ).orElse(0L);
-
-        return new PageImpl<>(planListResponses, pageable, total);
-
+        return getPlanList(email, pageable, false);
     }
 
-    @Override
     public Page<UserPlanListResponse> getMyPlanList(String email, Pageable pageable) {
+
+        return getPlanList(email, pageable, true);
+    }
+
+    private Page<UserPlanListResponse> getPlanList(String email, Pageable pageable, boolean isMyPlan) {
 
         updateIsFulledStatus();
 
-        JPAQuery<UserPlanListResponse> queryBuilder = queryFactory
+        BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(plan.deletedAt.isNull());
+        if (isMyPlan) {
+            whereClause.and(plan.user.email.eq(email));
+        } else {
+            whereClause.and(plan.user.email.ne(email));
+        }
+
+        List<UserPlanListResponse> results = queryFactory
                 .select(
                         Projections.constructor(
                                 UserPlanListResponse.class,
@@ -374,31 +224,21 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .from(plan)
                 .leftJoin(plan.user, user)
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
-                .where(attendance.user.email.eq(email)) // 유저가 참여한 일정
-                .where(plan.meeting.deletedAt.isNull())
-                .where(plan.user.email.eq(email)) // 유저가 만든 일정
-                .orderBy(plan.createdAt.desc());
-
-        // 페이징 처리
-        List<UserPlanListResponse> planListResponses = queryBuilder
-                .limit(pageable.getPageSize())
+                .where(whereClause)
+                .groupBy(plan.id) // 그룹화
+                .orderBy(plan.createdAt.desc())
                 .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
                 .fetch();
 
-        // 총 개수 조회
-        long total = Optional.ofNullable(
-                queryFactory
-                        .select(plan.count())
+        long total = Objects.requireNonNullElse(
+                queryFactory.select(plan.count())
                         .from(plan)
-                        .leftJoin(attendance).on(attendance.plan.eq(plan))
-                        .where(attendance.user.email.eq(email))
-                        .where(plan.meeting.deletedAt.isNull())
-                        .where(plan.user.email.eq(email))
-                        .fetchOne()
-        ).orElse(0L);
+                        .where(whereClause)
+                        .fetchOne(), 0L
+        );
 
-        return new PageImpl<>(planListResponses, pageable, total);
-
+        return new PageImpl<>(results, pageable, total);
     }
 
     @Override

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -76,8 +76,8 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .from(meeting)
                 .leftJoin(meeting.user, user)
                 .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                .where(meeting.user.email.eq(email) // 유저가 작성한 모임
-                        .or(meetingMember.user.email.eq(email))) // 유저가 가입한 모임
+                .where(meetingMember.user.email.eq(email)) // 유저가 가입한 모임
+                .where(meeting.user.email.ne(email)) // 유저가 만든 모임이 아닌 경우
                 .where(meeting.deletedAt.isNull())
                 .groupBy(meeting.id) // 그룹화
                 .orderBy(meeting.createdAt.desc());
@@ -94,13 +94,73 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .select(meeting.count())
                         .from(meeting)
                         .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
-                        .where(meeting.user.email.eq(email)
-                                .or(meetingMember.user.email.eq(email)))
+                        .where(meetingMember.user.email.eq(email)) // 유저가 가입한 모임
+                        .where(meeting.user.email.ne(email)) // 유저가 만든 모임이 아닌 경우
                         .where(meeting.deletedAt.isNull())
                         .fetchOne()
         ).orElse(0L);
 
         return new PageImpl<>(userMeetingListResponses, pageable, total);
+    }
+
+    @Override
+    public Page<UserMeetingListResponse> getMyMeetingList(String email, Pageable pageable) {
+
+        // 메인 쿼리
+        JPAQuery<UserMeetingListResponse> queryBuilder = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserMeetingListResponse.class,
+                                meeting.user.email,
+                                meeting.id,
+                                meeting.meetingName,
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(meeting.id),
+                                                        image.entityType.eq(Image.EntityType.MEETING),
+                                                        image.main.eq(true)),
+                                        "meetingImagePath"
+                                ),
+                                meeting.category.categoryName,
+                                Expressions.as(
+                                        JPAExpressions.select(meetingMember.count())
+                                                .from(meetingMember)
+                                                .where(meetingMember.meeting.id.eq(meeting.id)
+                                                        .and(meetingMember.deletedAt.isNull())),
+                                        "memberCount"
+                                ),
+                                meeting.createdAt,
+                                meeting.updatedAt
+                        )
+                )
+                .from(meeting)
+                .leftJoin(meeting.user, user)
+                .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
+                .where(meeting.user.email.eq(email)) // 유저가 작성한 모임
+                .where(meeting.deletedAt.isNull())
+                .groupBy(meeting.id) // 그룹화
+                .orderBy(meeting.createdAt.desc());
+
+        // 페이징 처리
+        List<UserMeetingListResponse> userMeetingListResponses = queryBuilder
+                .limit(pageable.getPageSize())
+                .offset(pageable.getOffset())
+                .fetch();
+
+        // 총 개수 조회
+        long total = Optional.ofNullable(
+                queryFactory
+                        .select(meeting.count())
+                        .from(meeting)
+                        .leftJoin(meetingMember).on(meetingMember.meeting.eq(meeting))
+                        .where(meeting.user.email.eq(email)) // 유저가 작성한 모임
+                        .where(meeting.deletedAt.isNull())
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new PageImpl<>(userMeetingListResponses, pageable, total);
+
     }
 
     @Override

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -18,6 +18,8 @@ public interface UserService {
 
     UserInfoResponse getUserInfo(String email);
 
+    UserMeetingPagingResponse getMeetingList(String email, Pageable pageable);
+
     UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable);
 
     UserPlanPagingResponse getMyPlanList(String email, Pageable pageable);

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -22,6 +22,8 @@ public interface UserService {
 
     UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable);
 
+    UserPlanPagingResponse getPlanList(String email, Pageable pageable);
+
     UserPlanPagingResponse getMyPlanList(String email, Pageable pageable);
 
     UserReviewPagingResponse getMyReviewList(String email, Pageable pageable);

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -140,9 +140,22 @@ public class UserServiceImpl implements UserService {
      * @return 유저가 속한 모임 목록
      */
     @Override
-    public UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable) {
+    public UserMeetingPagingResponse getMeetingList(String email, Pageable pageable) {
 
         return new UserMeetingPagingResponse(userRepository.getUserMeetingList(email, pageable));
+    }
+
+    /**
+     * 내가 만든 모임 목록 조회
+     *
+     * @param email    사용자 이메일
+     * @param pageable 페이징 처리 데이터
+     * @return 유저가 만든 모임 목록
+     */
+    @Override
+    public UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable) {
+
+        return new UserMeetingPagingResponse(userRepository.getMyMeetingList(email, pageable));
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -167,9 +167,23 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     @Transactional
-    public UserPlanPagingResponse getMyPlanList(String email, Pageable pageable) {
+    public UserPlanPagingResponse getPlanList(String email, Pageable pageable) {
 
         return new UserPlanPagingResponse(userRepository.getUserPlanList(email, pageable));
+    }
+
+    /**
+     * 내가 만든 일정 목록 조회
+     *
+     * @param email    사용자 이메일
+     * @param pageable 페이징 처리 데이터
+     * @return 유저가 만든 일정 목록
+     */
+    @Override
+    @Transactional
+    public UserPlanPagingResponse getMyPlanList(String email, Pageable pageable) {
+
+        return new UserPlanPagingResponse(userRepository.getMyPlanList(email, pageable));
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 내 모임 목록 조회 API를 내가 만든 모임과 다른 유저가 만든 모임으로 분리하였습니다.
- 내 일정 목록 조회 API를 내가 만든 일정과 다른 유저가 만든 일정으로 분리하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/mypage-103` -> `dev`
- close #103

<br/>

## 🔥 트러블 슈팅 (선택)
- **문제**: 내 모임 목록을 조회할 때, 내가 만든 모임과 가입한 모임을 구분하여 조회하는 API가 필요했음. 그러나 모임과 유저 간의 관계에서 조인하는 과정에서 오류 발생
- **해결 방법**:
  - `.where(user.email.ne(email))` 조건을 통해 유저가 생성한 모임과 가입한 모임을 구분
  - 기존에는 `meeting`을 기준으로 `meetingMember`를 조회했으나, 회원이 속한 모임을 찾기 위해서는 `meetingMember`를 기준으로 `meeting`을 조인해야 했음
  - 이를 해결하기 위해, `meetingMember`를 먼저 조회한 후 해당하는 `meeting`을 가져오도록 로직을 변경
