### PR TITLE
[Fix] 일정 목록 조회 시 마감임박 순 필터링 오류 해결

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -9,6 +9,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.dto.PlanListResponse;
+import com.wemo.backend.domain.plan.entity.Plan;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
@@ -65,8 +66,28 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         // 1. 목록 조회 쿼리 (커서 조건 포함)
         BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
         if (cursor != null) {
-            listConditions.and(plan.id.lt(cursor));
+            Plan targetPlan = queryFactory
+                    .selectFrom(plan)
+                    .where(plan.id.eq(cursor))
+                    .fetchOne();
+
+            if (targetPlan != null) {
+                LocalDateTime cursorCloseDate = targetPlan.getRegistrationEnd();
+
+                if (sortField.equals("closeDate")) {
+                    listConditions.and(
+                            plan.registrationEnd.gt(cursorCloseDate) // 현재 커서 이후의 마감일 데이터
+                                    .or(
+                                            plan.registrationEnd.eq(cursorCloseDate)
+                                                    .and(plan.id.gt(cursor)) // 마감일자가 같으면 planId 기준 정렬
+                                    )
+                    );
+                } else {
+                    listConditions.and(plan.id.lt(cursor));
+                }
+            }
         }
+
 
         List<PlanListResponse> planListResponses = queryFactory
                 .select(buildPlanListProjection(email))
@@ -75,7 +96,11 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                 .where(listConditions)
                 .where(plan.canceled.eq(false))
                 .where(plan.meeting.deletedAt.isNull())
-                .orderBy(sortField.equals("closeDate") ? plan.registrationEnd.asc() : plan.createdAt.desc())
+                .orderBy(
+                        sortField.equals("closeDate")
+                                ? plan.registrationEnd.asc().nullsLast()
+                                : plan.createdAt.desc(),
+                        plan.id.asc()) // 마감일자가 같으면 planId 기준 추가 정렬
                 .limit(size)
                 .fetch();
 
@@ -206,7 +231,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
             if (categoryId == 1) {
                 condition = condition.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
             } else {
-                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 id로만 필터링
+                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 해당 id 필터링
             }
         }
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)  
- 일정 목록 조회 시 **마감 임박 순 필터링**에서 `planId` 기준으로 `cursorId`를 처리하던 방식을 **마감 날짜 순으로 변경**  
- 커서 기반 페이징 시 **마감 날짜 이후의 데이터**를 정상적으로 가져올 수 있도록 수정  

<br/>

## 🌱 반영 브랜치  
- `refactor/plan-list-105` -> `dev`  
- close #105  

<br/>

## 🔥 트러블 슈팅 (선택)  
### 💡 **문제**  
- 기존에는 `planId`를 커서로 사용하여 페이징을 진행했음  
- 그러나 마감 임박 순 정렬 시, 특정 `planId`가 중간에 위치한 경우 **이전 `planId`를 기준으로 조회할 때 누락되는 데이터가 발생**  
  - 예: `planId=1`이 중간에 있는 경우, `planId < 1` 조건에 의해 일부 데이터가 조회되지 않음  

### ✅ **해결**  
1. `cursor=planId`가 주어졌을 때, **해당 `planId`의 마감 일자(registrationEnd)를 먼저 조회**  
2. 이후 **마감 일자가 더 뒤에 있는 데이터**를 가져오도록 변경  
3. 동일한 `registrationEnd`를 가진 경우, `planId`를 기준으로 추가 정렬하여 순서 유지  

**마감 임박 순 페이징에서도 데이터 누락 없이 정상적으로 동작**하도록 수정 완료! 🚀  
