### PR TITLE
[Refactor] 일정 목록 조회 시 위도, 경도 기반 조회 기능 추가

### DIFF
--- a/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/wemo/backend/domain/plan/controller/PlanController.java
@@ -71,9 +71,12 @@ public class PlanController {
                                                                                  @RequestParam(required = false) String startDate,
                                                                                  @RequestParam(required = false) String endDate,
                                                                                  @RequestParam(required = false) Long categoryId,
-                                                                                 @RequestParam(required = false) String sort) {
+                                                                                 @RequestParam(required = false) String sort,
+                                                                                 @RequestParam(required = false) Double latitude,
+                                                                                 @RequestParam(required = false) Double longitude,
+                                                                                 @RequestParam(required = false, defaultValue = "1.0") Double radius) {
 
-        PlanCursorPagingResponse response = planService.getPlanList(userDetails, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        PlanCursorPagingResponse response = planService.getPlanList(userDetails, cursor, size, query, province, district, startDate, endDate, categoryId, sort, latitude, longitude, radius);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 

--- a/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/plan/dto/PlanListResponse.java
@@ -30,6 +30,10 @@ public class PlanListResponse {
 
     private String district;
 
+    private double latitude;
+
+    private double longitude;
+
     private String planImagePath;
 
     private LocalDateTime dateTime;
@@ -47,7 +51,7 @@ public class PlanListResponse {
     private LocalDateTime createdAt;
 
     private LocalDateTime updatedAt;
-    
+
     @JsonProperty("isOpened")
     private boolean isOpened;
 
@@ -59,16 +63,19 @@ public class PlanListResponse {
 
     @JsonProperty("isOpened")
     public boolean getIsOpened() {
+
         return isOpened;
     }
 
     @JsonProperty("isFulled")
     public boolean getIsFulled() {
+
         return isFulled;
     }
 
     @JsonProperty("isLiked")
     public boolean getIsLiked() {
+
         return isLiked;
     }
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDsl.java
@@ -4,8 +4,8 @@ import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 
 public interface PlanCursorQueryDsl {
 
-    PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+    PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius);
 
-    PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+    PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
@@ -40,18 +41,18 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
     }
 
     @Override
-    public PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+    public PlanCursorPagingResponse getPlanListByUser(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius) {
 
-        return getPlanList(email, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        return getPlanList(email, cursor, size, query, province, district, startDate, endDate, categoryId, sort, latitude, longitude, radius);
     }
 
     @Override
-    public PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+    public PlanCursorPagingResponse getPlanListByGuest(Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius) {
 
-        return getPlanList(null, cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+        return getPlanList(null, cursor, size, query, province, district, startDate, endDate, categoryId, sort, latitude, longitude, radius);
     }
 
-    private PlanCursorPagingResponse getPlanList(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+    private PlanCursorPagingResponse getPlanList(String email, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius) {
 
         updateIsFulledStatus();
 
@@ -61,7 +62,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
 
         // 커서 조건을 제외한 기본 조건 빌더
         BooleanBuilder baseConditions = new BooleanBuilder()
-                .and(buildFilterConditions(query, province, district, startDate, endDate, categoryId));
+                .and(buildFilterConditions(query, province, district, startDate, endDate, categoryId, latitude, longitude, radius));
 
         // 1. 목록 조회 쿼리 (커서 조건 포함)
         BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
@@ -202,12 +203,9 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         );
     }
 
-    private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
-
-        return getBooleanExpression(query, province, district, startDate, endDate, categoryId);
-    }
-
-    static BooleanExpression getBooleanExpression(String query, String province, String district, String startDate, String endDate, Long categoryId) {
+    private BooleanExpression buildFilterConditions(String query, String province, String district,
+                                                    String startDate, String endDate, Long categoryId,
+                                                    Double latitude, Double longitude, Double radius) {
 
         BooleanExpression condition = plan.canceled.eq(false);
 
@@ -231,9 +229,22 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
 
         if (categoryId != null) {
             if (categoryId == 1) {
-                condition = condition.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
+                condition = condition.and(plan.meeting.category.parentId.eq(categoryId));
             } else {
-                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 해당 id 필터링
+                condition = condition.and(plan.meeting.category.id.eq(categoryId));
+            }
+        }
+
+        // 위치 기반 필터링 추가 (필터가 없는 경우)
+        if ((province == null || province.isEmpty()) && (district == null || district.isEmpty())) {
+            if (latitude != null && longitude != null && radius != null) {
+                double radiusInMeters = radius * 1000; // km → m 변환
+
+                NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
+                        "ST_Distance_Sphere(point({0}, {1}), point(plan.longitude, plan.latitude))",
+                        longitude, latitude);
+
+                condition = condition.and(distance.loe(radiusInMeters));
             }
         }
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -156,6 +156,8 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                                 .where(plan.district.id.eq(district.id)),
                         "district"
                 ),
+                plan.latitude,
+                plan.longitude,
                 Expressions.as(
                         queryFactory.select(image.fileUrl)
                                 .from(image)

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +26,6 @@ import static com.wemo.backend.domain.image.entity.QImage.image;
 import static com.wemo.backend.domain.like.entity.QLikes.likes;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
-import static com.wemo.backend.domain.plan.repository.querydsl.PlanCursorQueryDslImpl.getBooleanExpression;
 import static com.wemo.backend.domain.user.entity.QUser.user;
 
 @Slf4j
@@ -175,7 +175,35 @@ public class PlanQueryDslImpl implements PlanQueryDsl {
 
     private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
 
-        return getBooleanExpression(query, province, district, startDate, endDate, categoryId);
+        BooleanExpression condition = plan.canceled.eq(false);
+
+        if (query != null && !query.isEmpty()) {
+            condition = condition.and(plan.planName.contains(query));
+        }
+
+        if (province != null && !province.isEmpty()) {
+            condition = condition.and(plan.district.province.provinceName.eq(province));
+        }
+
+        if (district != null && !district.isEmpty()) {
+            condition = condition.and(plan.district.districtName.eq(district));
+        }
+
+        if (startDate != null && !startDate.isEmpty() && endDate != null && !endDate.isEmpty()) {
+            LocalDate start = LocalDate.parse(startDate);
+            LocalDate end = LocalDate.parse(endDate);
+            condition = condition.and(plan.dateTime.between(start.atStartOfDay(), end.atTime(23, 59, 59)));
+        }
+
+        if (categoryId != null) {
+            if (categoryId == 1) {
+                condition = condition.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
+            } else {
+                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 해당 id 필터링
+            }
+        }
+
+        return condition;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanService.java
@@ -16,7 +16,7 @@ public interface PlanService {
 
     String joinPlan(String email, Long planId);
 
-    PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort);
+    PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius);
 
     PlanDetailResponse getPlanDetail(UserDetailsImpl userDetails, Long planId);
 

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -139,15 +139,18 @@ public class PlanServiceImpl implements PlanService {
      * @param endDate     끝 날짜
      * @param categoryId  카테고리 id
      * @param sort        정렬 기준
+     * @param latitude    위도
+     * @param longitude   경도
+     * @param radius      반경
      * @return 조건에 해당하는 일정 목록
      */
     @Override
     @Transactional
-    public PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
+    public PlanCursorPagingResponse getPlanList(UserDetailsImpl userDetails, Long cursor, int size, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort, Double latitude, Double longitude, Double radius) {
 
         return userDetails != null && !userDetails.isGuest()
-                ? planRepository.getPlanListByUser(userDetails.getUsername(), cursor, size, query, province, district, startDate, endDate, categoryId, sort)
-                : planRepository.getPlanListByGuest(cursor, size, query, province, district, startDate, endDate, categoryId, sort);
+                ? planRepository.getPlanListByUser(userDetails.getUsername(), cursor, size, query, province, district, startDate, endDate, categoryId, sort, latitude, longitude, radius)
+                : planRepository.getPlanListByGuest(cursor, size, query, province, district, startDate, endDate, categoryId, sort, latitude, longitude, radius);
     }
 
     /**


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 일정 장소의 **위도**와 **경도** 데이터를 지도에 표시할 수 있도록 추가했습니다.
- 사용자의 **위도**, **경도**, **반경**(radius)을 파라미터로 받아, 사용자 위치 기반으로 데이터를 조회할 수 있도록 구현했습니다.
  - **Double** 타입으로 위도, 경도, 반경을 받아 **null**을 허용할 수 있도록 처리했습니다.
- **좋아요한 일정 목록 조회**와 **일정 목록 조회**의 조회 조건이 달라졌기에 조건을 분리하여 코드 개선을 진행했습니다.
  - 사용자의 위치 기반 조회 시, 반경 조건을 `latitude`, `longitude` 값을 통해 필터링하고, 그 외 조건들을 별도로 처리하여 더욱 유연한 조회가 가능하도록 했습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/plan-list-105` -> `dev`
- close #105 

<br/>

## 🚀 향후 개선 사항
- 데이터가 많아질 경우 성능 문제가 발생할 수 있으므로, **Spatial Index** 추가를 고려하여 추후 성능 최적화를 진행할 예정입니다.
