### PR TITLE
[Fix] 쿠키 만료 설정 방법 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
+import java.util.Date;
+
 @Component
 public class AccessTokenManager {
 
@@ -15,14 +17,22 @@ public class AccessTokenManager {
      */
     public void setAccessTokenInCookie(String accessToken, HttpServletResponse response) {
 
+        // 현재 시간 + 5분
+        Date expiryDate = new Date(System.currentTimeMillis() + 5 * 60 * 1000);
+
+        // 쿠키 생성
         ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
-                .maxAge(5 * 60)
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
                 .path("/")
                 .build();
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        // 쿠키 설정 후 만료 시간을 Expires 헤더에 추가
+        String cookieWithExpiry = cookie + "; Expires=" + expiryDate;
+
+        // 최종 쿠키를 응답에 추가
+        response.addHeader(HttpHeaders.SET_COOKIE, cookieWithExpiry);
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 쿠키 설정 방법을 `maxAge`에서 `expires`로 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/cookie-108` -> `dev`
- close #108 

<br/>

## 🔥 트러블 슈팅 (선택)
- `maxAge` 설정으로 인해 브라우저 내에서 자동으로 쿠키가 삭제되어 만료된 토큰을 전달하지 못하는 이슈 발생
- `maxAge` 대신 `expires` 설정으로 만료 시간을 설정하여 만료되어도 브라우저 내에서 자동으로 토큰이 삭제되지 않도록 수정
