### PR TITLE
[Refactor] accessToken 재발급 로직 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -42,6 +42,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             String accessToken = getTokenFromCookie(request, "accessToken");
             String refreshToken = getTokenFromCookie(request, "Refresh-Token");
+            log.info("accessToken: {}, refreshToken : {}", accessToken, refreshToken);
 
             if (shouldSkipFilter(request.getRequestURI(), request.getMethod(), accessToken)) {
                 filterChain.doFilter(request, response);
@@ -99,14 +100,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private boolean validateLogoutRequest(String accessToken, String refreshToken, HttpServletResponse response)
             throws IOException {
 
+        // accessToken 과 refreshToken 모두 유효하지 않은 경우 로그아웃 실패
         if (!jwtTokenProvider.validateAccessToken(accessToken) && !jwtTokenProvider.validateRefreshToken(refreshToken)) {
             sendErrorResponse(response, "accessToken과 refreshToken 모두 유효하지 않습니다.", HttpStatus.UNAUTHORIZED);
             return false;
         }
+
+        // accessToken 만료 여부에 관계없이 refreshToken 이 만료된 경우 로그아웃 실패
         if (!jwtTokenProvider.validateRefreshToken(refreshToken)) {
             sendErrorResponse(response, "유효하지 않은 refreshToken입니다.", HttpStatus.BAD_REQUEST);
             return false;
         }
+
+        // accessToken 이 유효하지 않은 경우 (값이 존재하지 않거나 이미 로그아웃된 토큰인 경우)
         if (!jwtTokenProvider.validateAccessToken(accessToken)) {
             sendErrorResponse(response, "유효하지 않은 accessToken입니다.", HttpStatus.BAD_REQUEST);
             return false;

--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -49,35 +49,43 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
 
             if ("/api/auths/signout".equals(request.getRequestURI()) && !validateLogoutRequest(accessToken, refreshToken, response)) {
-                return;
+                return; // 응답 후 중단
             }
 
-            validateAccessToken(accessToken, response);
-            setAuthentication(accessToken, request.getRequestURI());
+            if (!validateAccessToken(accessToken, response)) {
+                return; // 응답 후 중단
+            }
 
+            setAuthentication(accessToken, request.getRequestURI());
             filterChain.doFilter(request, response);
+
         } catch (Exception e) {
             log.error("필터 처리 중 에러 발생: {}", e.getMessage());
-            sendErrorResponse(response, "서버 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+            if (!response.isCommitted()) { // 응답이 이미 전송되지 않은 경우에만 에러 응답 전송
+                sendErrorResponse(response, "서버 에러가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
+            }
         }
     }
 
-    private void validateAccessToken(String accessToken, HttpServletResponse response) throws IOException {
+    private boolean validateAccessToken(String accessToken, HttpServletResponse response) throws IOException {
 
         if (accessToken == null || accessToken.isEmpty()) {
             sendErrorResponse(response, "accessToken이 요청에 포함되지 않았습니다.", HttpStatus.BAD_REQUEST);
-            return;
+            return false;
         }
         if (tokenBlacklistService.isBlacklisted(accessToken)) {
             sendErrorResponse(response, "이미 로그아웃된 토큰입니다. 로그인 후 다시 시도해주세요.", HttpStatus.UNAUTHORIZED);
-            return;
+            return false;
         }
         try {
             jwtTokenProvider.parseToken(accessToken);
+            return true;
         } catch (TokenExpiredException e) {
             sendErrorResponse(response, "만료된 토큰입니다.", HttpStatus.UNAUTHORIZED);
+            return false;
         } catch (Exception e) {
             sendErrorResponse(response, "유효하지 않은 토큰입니다.", HttpStatus.UNAUTHORIZED);
+            return false;
         }
     }
 
@@ -115,6 +123,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message, HttpStatus httpStatus) throws IOException {
+
+        if (response.isCommitted()) return; // 이미 응답이 전송된 경우 중단
 
         response.setStatus(httpStatus.value());
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
@@ -25,6 +25,9 @@ import java.util.Date;
 @RequiredArgsConstructor
 public class JwtTokenProvider {
 
+    @Value("${JWT_ISSUER}")
+    private String JWT_ISSUER;
+
     @Value("${JWT_SECRET_KEY}")
     private String JWT_SECRET;
 
@@ -145,16 +148,31 @@ public class JwtTokenProvider {
         }
 
         try {
+            // JWT 파싱 및 만료 시간 확인
+            DecodedJWT decodedJWT = JWT.require(Algorithm.HMAC256(JWT_SECRET))
+                    .withIssuer(JWT_ISSUER)
+                    .build()
+                    .verify(refreshToken);
+
+            Date expiresAt = decodedJWT.getExpiresAt();
+            if (expiresAt != null && expiresAt.before(new Date())) {  // 현재 시간보다 과거면 만료됨
+                log.warn("refreshToken이 만료되었습니다. 만료 시간: {}", expiresAt);
+                return false;
+            }
+
             // refreshToken 조회
             RefreshToken foundRefreshToken = refreshTokenManager.getRefreshToken(refreshToken);
 
             // refreshToken 존재 여부 확인
-            if (foundRefreshToken != null && foundRefreshToken.refreshToken() != null && foundRefreshToken.email().equals(decodeUsername(refreshToken))) {
+            if (foundRefreshToken != null && foundRefreshToken.refreshToken() != null
+                    && foundRefreshToken.email().equals(decodeUsername(refreshToken))) {
                 log.info("유효한 refreshToken입니다.");
                 return true;
             } else {
                 log.warn("DB에 해당 refreshToken이 존재하지 않습니다.");
             }
+        } catch (TokenExpiredException e) {
+            log.warn("refreshToken이 만료되었습니다.: {}", e.getMessage());
         } catch (IllegalArgumentException e) {
             log.error("잘못된 refreshToken입니다.: {}", e.getMessage());
         } catch (Exception e) {

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
@@ -1,12 +1,14 @@
 package com.wemo.backend.domain.auth.token.service;
 
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
 
+@Slf4j
 @Component
 public class AccessTokenManager {
 
@@ -33,6 +35,22 @@ public class AccessTokenManager {
 
         // 최종 쿠키를 응답에 추가
         response.addHeader(HttpHeaders.SET_COOKIE, cookieWithExpiry);
+    }
+
+    public void deleteAccessTokenInCookie(HttpServletResponse response) {
+
+        ResponseCookie cookie = ResponseCookie.from("accessToken", null)
+                .maxAge(0) // 쿠키 즉시 만료
+                .sameSite("None") // 쿠키 SameSite 설정
+                .secure(true) // HTTPS 환경에서만 전송
+                .httpOnly(true) // JavaScript에서 접근 불가
+                .path("/") // 모든 경로에서 유효
+                .build();
+
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString()); // 헤더에 쿠키 추가
+
+        log.info("accessToken 쿠키 삭제 완료");
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -104,14 +104,9 @@ public class RefreshTokenManager {
         if (email == null) {
             throw new CustomException(ILLEGAL_REFRESH_TOKEN_NOT_VALID);
         }
-        // 유효성 검사 후 기존 발급된 refreshToken 삭제
-        refreshTokenRepository.delete(getRefreshToken(refreshToken));
 
         String newAccessToken = jwtTokenUtils.generateAccessToken(email);
-        String newRefreshToken = jwtTokenUtils.generateRefreshToken(email);
-
         accessTokenManager.setAccessTokenInCookie(newAccessToken, response);
-        setRefreshTokenInCookie(newRefreshToken, response);
 
         log.info("토큰 생성 후 헤더에 담기 완료!");
     }

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -72,15 +73,11 @@ public class UserController {
                     content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/signout", method = RequestMethod.POST)
-    public ResponseEntity<SuccessResponse<String>> signout(
-            @RequestHeader("Authorization") String accessToken,
-            @RequestHeader("Refresh-Token") String refreshToken,
-            HttpServletResponse response) {
+    public ResponseEntity<SuccessResponse<String>> signout(HttpServletRequest request,
+                                                           HttpServletResponse response) {
 
-        log.info("accessToken : {}", accessToken);
-        log.info("refreshToken : {}", refreshToken);
-
-        return ResponseEntity.ok().body(SuccessResponse.successWithNoData(userService.signout(accessToken, refreshToken, response)));
+        log.info("로그아웃 controller 탄다");
+        return ResponseEntity.ok().body(SuccessResponse.successWithNoData(userService.signout(request, response)));
     }
 
     @Operation(summary = "회원 정보 조회", description = "사용자가 회원 정보를 조회합니다.")

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.user.service;
 
 import com.wemo.backend.domain.user.dto.*;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,7 @@ public interface UserService {
 
     void signin(SigninRequest request, HttpServletResponse response);
 
-    String signout(String accessToken, String refreshToken, HttpServletResponse response);
+    String signout(HttpServletRequest request, HttpServletResponse response);
 
     UserInfoResponse getUserInfo(String email);
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -6,6 +6,7 @@ import com.wemo.backend.domain.auth.JwtTokenProvider;
 import com.wemo.backend.domain.auth.UserAuth;
 import com.wemo.backend.domain.auth.token.entity.RefreshToken;
 import com.wemo.backend.domain.auth.token.repository.RefreshTokenRepository;
+import com.wemo.backend.domain.auth.token.service.AccessTokenManager;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.auth.token.service.TokenBlacklistService;
 import com.wemo.backend.domain.like.entity.Likes;
@@ -15,6 +16,8 @@ import com.wemo.backend.domain.review.service.ReviewReader;
 import com.wemo.backend.domain.user.dto.*;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -40,6 +45,7 @@ public class UserServiceImpl implements UserService {
     private final AttendanceReader attendanceReader;
     private final LikeReader likeReader;
     private final ReviewReader reviewReader;
+    private final AccessTokenManager accessTokenManager;
 
     /**
      * 이메일 중복 검사
@@ -88,21 +94,20 @@ public class UserServiceImpl implements UserService {
     /**
      * 로그아웃
      *
-     * @param accessToken  accessToken
-     * @param refreshToken refreshToken
      * @return 응답 메세지
      */
     @Override
     @Transactional
-    public String signout(String accessToken, String refreshToken, HttpServletResponse response) {
+    public String signout(HttpServletRequest request, HttpServletResponse response) {
 
-        // Bearer 제거
-        String cleanToken = accessToken.replace("Bearer ", "");
+        String accessToken = getTokenFromCookie(request, "accessToken");
+        String refreshToken = getTokenFromCookie(request, "Refresh-Token");
 
         // accessToken 검증 및 블랙리스트 처리
-        Long expiration = jwtTokenProvider.getExpiration(cleanToken);
-        tokenBlacklistService.addToBlacklist(cleanToken, expiration);
+        Long expiration = jwtTokenProvider.getExpiration(accessToken);
+        tokenBlacklistService.addToBlacklist(accessToken, expiration);
         log.info("accessToken 블랙리스트에 추가 완료");
+        accessTokenManager.deleteAccessTokenInCookie(response);
 
         // refreshToken 삭제
         RefreshToken findRefreshToken = refreshTokenManager.getRefreshToken(refreshToken);
@@ -243,6 +248,16 @@ public class UserServiceImpl implements UserService {
         User user = userReader.getUserByEmail(email);
 
         user.saveAdditionalData(request);
+    }
+
+    private String getTokenFromCookie(HttpServletRequest request, String tokenName) {
+
+        return Optional.ofNullable(request.getCookies())
+                .flatMap(cookies -> Arrays.stream(cookies)
+                        .filter(cookie -> tokenName.equals(cookie.getName()))
+                        .map(Cookie::getValue)
+                        .findFirst())
+                .orElse(null);
     }
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- accessToken 재발급 시 refreshToken 재발급 로직 제거하였습니다.
- 오류가 중복 발생하는 것을 방지하기 위해 필터 코드 수정하였습니다.
- refreshToken 만료시간 검증 로직 추가하였습니다.
- 로그아웃 시 accessToken의 만료시간을 초기화하여 무력화하였습니다.
- 필터 단에 로그 및 주석 추가하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/cookie-108` -> `dev`
- close #108 

<br/>

## 🔥 트러블 슈팅 (선택)
- refreshToken 재발급으로 인한 유효하지 않은 refreshToken 예외 반복 발생
   -> AccessToken 재발급 시 함께 진행되던 refreshToken 재발급 로직이 원인이었으며, 이를 제거하여 예외가 반복되지 않도록 수정
