### PR TITLE
[Refactor] 내 일정 목록 조회 기능 2차 개발

### DIFF
--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -70,6 +70,21 @@ public class UserDashboardController {
 
     }
 
+    @Operation(summary = "내 일정 목록 조회", description = "유저가 참여한 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 참여한 일정의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/plans/v2", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getPlanListV2(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                 @RequestParam(defaultValue = "1") int page,
+                                                                                 @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getPlanListV2(userDetails.getUsername(), pageable)));
+
+    }
+
     @Operation(summary = "내가 만든 일정 목록 조회", description = "유저가 만든 일정의 목록을 반환합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "내가 만든 일정의 목록이 반환되었습니다.")
@@ -82,6 +97,21 @@ public class UserDashboardController {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
 
         return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyPlanList(userDetails.getUsername(), pageable)));
+
+    }
+
+    @Operation(summary = "내가 만든 일정 목록 조회", description = "유저가 만든 일정의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "내가 만든 일정의 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "/plans/me/v2", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<UserPlanPagingResponse>> getMyPlanListV2(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                   @RequestParam(defaultValue = "1") int page,
+                                                                                   @RequestParam(defaultValue = "10") int size) {
+
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by("createdAt").descending());
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(userService.getMyPlanListV2(userDetails.getUsername(), pageable)));
 
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponseV2.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponseV2.java
@@ -1,0 +1,98 @@
+package com.wemo.backend.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class UserPlanListResponseV2 {
+
+    private String nickname;
+
+    private String email;
+
+    private String profileImagePath;
+
+    private Long planId;
+
+    private String planName;
+
+    private String category;
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String address;
+
+    private String province;
+
+    private String district;
+
+    private String planImagePath;
+
+    private LocalDateTime dateTime;
+
+    private LocalDateTime registrationEnd;
+
+    private int capacity;
+
+    private Long participants;
+
+    private Long likeCount;
+
+    private int viewCount;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @JsonProperty("isOpened")
+    private boolean isOpened;
+
+    @JsonProperty("isUpcoming")
+    private boolean isUpcoming;
+
+    @JsonProperty("isCanceled")
+    private boolean isCanceled;
+
+    @JsonProperty("isCompleted")
+    private boolean isCompleted;
+
+    @JsonProperty("isLiked")
+    private boolean isLiked;
+
+    @JsonProperty("isOpened")
+    public boolean getIsOpened() {
+
+        return isOpened;
+    }
+
+    @JsonProperty("isUpcoming")
+    public boolean getIsUpcoming() {
+
+        return isUpcoming;
+    }
+
+    @JsonProperty("isCanceled")
+    public boolean getIsCanceled() {
+
+        return isCanceled;
+    }
+
+    @JsonProperty("isCompleted")
+    public boolean getIsCompleted() {
+
+        return isCompleted;
+    }
+
+    @JsonProperty("isLiked")
+    public boolean getIsLiked() {
+
+        return isLiked;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDsl.java
@@ -1,9 +1,6 @@
 package com.wemo.backend.domain.user.repository.querydsl;
 
-import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
-import com.wemo.backend.domain.user.dto.UserPlanListResponse;
-import com.wemo.backend.domain.user.dto.UserPlanReviewableListResponse;
-import com.wemo.backend.domain.user.dto.UserReviewListResponse;
+import com.wemo.backend.domain.user.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -20,5 +17,9 @@ public interface UserQueryDsl {
     Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable);
 
     Page<UserPlanReviewableListResponse> getUserPlanListReviewAvailable(String email, Pageable pageable);
+
+    Page<UserPlanListResponseV2> getUserPlanListV2(String email, Pageable pageable);
+
+    Page<UserPlanListResponseV2> getMyPlanListV2(String email, Pageable pageable);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -2,15 +2,13 @@ package com.wemo.backend.domain.user.repository.querydsl;
 
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
-import com.wemo.backend.domain.user.dto.UserMeetingListResponse;
-import com.wemo.backend.domain.user.dto.UserPlanListResponse;
-import com.wemo.backend.domain.user.dto.UserPlanReviewableListResponse;
-import com.wemo.backend.domain.user.dto.UserReviewListResponse;
+import com.wemo.backend.domain.user.dto.*;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -18,6 +16,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -134,7 +133,12 @@ public class UserQueryDslImpl implements UserQueryDsl {
         if (isMyPlan) {
             whereClause.and(plan.user.email.eq(email));
         } else {
-            whereClause.and(plan.user.email.ne(email));
+            whereClause.and(plan.user.email.ne(email)) // 사용자가 만든 일정이 아니어야 함
+                    .and(plan.id.in(
+                            JPAExpressions.select(attendance.plan.id)
+                                    .from(attendance)
+                                    .where(attendance.user.email.eq(email))
+                    )); // 사용자가 참여한 일정만 가져오기
         }
 
         List<UserPlanListResponse> results = queryFactory
@@ -373,6 +377,146 @@ public class UserQueryDslImpl implements UserQueryDsl {
         ).orElse(0L);
 
         return new PageImpl<>(reviewListResponses, pageable, total);
+    }
+
+    @Override
+    public Page<UserPlanListResponseV2> getUserPlanListV2(String email, Pageable pageable) {
+
+        return getPlanListV2(email, pageable, false);
+    }
+
+    @Override
+    public Page<UserPlanListResponseV2> getMyPlanListV2(String email, Pageable pageable) {
+
+        return getPlanListV2(email, pageable, true);
+    }
+
+    private Page<UserPlanListResponseV2> getPlanListV2(String email, Pageable pageable, boolean isMyPlan) {
+
+        updateIsFulledStatus();
+
+        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9)); // KST 시간으로 현재 시간 얻기
+        log.info("nowKST 현재 시각 : {}", nowKST);
+
+        BooleanExpression isUpcoming = plan.dateTime.after(nowKST).and(plan.opened.eq(true));
+        BooleanExpression isCompleted = plan.dateTime.before(nowKST);
+
+        BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(plan.deletedAt.isNull());
+        if (isMyPlan) {
+            whereClause.and(plan.user.email.eq(email));
+        } else {
+            whereClause.and(plan.user.email.ne(email)) // 사용자가 만든 일정이 아니어야 함
+                    .and(plan.id.in(
+                            JPAExpressions.select(attendance.plan.id)
+                                    .from(attendance)
+                                    .where(attendance.user.email.eq(email))
+                    )); // 사용자가 참여한 일정만 가져오기
+        }
+
+        List<UserPlanListResponseV2> results = queryFactory
+                .select(
+                        Projections.constructor(
+                                UserPlanListResponseV2.class,
+                                user.nickname.as("nickname"),
+                                user.email.as("email"),
+                                user.profileImagePath.as("profileImage"),
+                                plan.id.as("planId"),
+                                plan.planName,
+                                Expressions.as(
+                                        queryFactory.select(meeting.category.categoryName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "category"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.id)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingId"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(meeting.meetingName)
+                                                .from(meeting)
+                                                .where(meeting.id.eq(plan.meeting.id)),
+                                        "meetingName"
+                                ),
+                                plan.address,
+                                Expressions.as(
+                                        queryFactory.select(province.provinceName)
+                                                .from(province)
+                                                .where(plan.district.province.id.eq(province.id)),
+                                        "province"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(district.districtName)
+                                                .from(district)
+                                                .where(plan.district.id.eq(district.id)),
+                                        "district"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(image.fileUrl)
+                                                .from(image)
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
+                                                        image.main.eq(true)),
+                                        "planImagePath"
+                                ),
+                                plan.dateTime,
+                                plan.registrationEnd,
+                                plan.capacity,
+                                Expressions.as(
+                                        queryFactory.select(attendance.count())
+                                                .from(attendance)
+                                                .where(attendance.plan.id.eq(plan.id)
+                                                        .and(attendance.deletedAt.isNull())),
+                                        "participants"
+                                ),
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(likes.plan.id.eq(plan.id)),
+                                        "likesCount"
+                                ),
+                                plan.viewCount,
+                                plan.createdAt,
+                                plan.updatedAt,
+                                plan.opened,
+                                isUpcoming,
+                                plan.canceled,
+                                isCompleted,
+                                Expressions.as(
+                                        queryFactory.select(likes.count())
+                                                .from(likes)
+                                                .where(
+                                                        likes.plan.id.eq(plan.id)
+                                                                .and(
+                                                                        email != null
+                                                                                ? likes.user.email.eq(email)
+                                                                                : likes.user.email.isNull()
+                                                                )
+                                                ).gt(0L),
+                                        "isLiked")
+                        )
+                )
+                .from(plan)
+                .leftJoin(plan.user, user)
+                .leftJoin(attendance).on(attendance.plan.eq(plan))
+                .where(whereClause)
+                .groupBy(plan.id) // 그룹화
+                .orderBy(plan.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = Objects.requireNonNullElse(
+                queryFactory.select(plan.count())
+                        .from(plan)
+                        .where(whereClause)
+                        .fetchOne(), 0L
+        );
+
+        return new PageImpl<>(results, pageable, total);
     }
 
     private void updateIsFulledStatus() {

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -35,4 +35,8 @@ public interface UserService {
 
     void saveAdditionalUserData(String email, AdditionalDataRequest request);
 
+    UserPlanPagingResponse getPlanListV2(String email, Pageable pageable);
+
+    UserPlanPagingResponse getMyPlanListV2(String email, Pageable pageable);
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -242,6 +242,20 @@ public class UserServiceImpl implements UserService {
         user.saveAdditionalData(request);
     }
 
+    @Override
+    @Transactional
+    public UserPlanPagingResponse getPlanListV2(String email, Pageable pageable) {
+
+        return new UserPlanPagingResponse(userRepository.getUserPlanListV2(email, pageable));
+    }
+
+    @Override
+    @Transactional
+    public UserPlanPagingResponse getMyPlanListV2(String email, Pageable pageable) {
+
+        return new UserPlanPagingResponse(userRepository.getMyPlanListV2(email, pageable));
+    }
+
     private String getTokenFromCookie(HttpServletRequest request, String tokenName) {
 
         return Optional.ofNullable(request.getCookies())


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 2차 개발 API 명세에 맞춰 기능 수정 작업을 진행하며 `v2` 버전의 API를 추가했습니다.
- 기존 API와 구분을 위해 엔드포인트에 `v2`를 추가하였습니다.
- `isUpcoming` 컬럼과 `isCompleted` 컬럼을 추가하여 일정의 상태를 명확히 표현하도록 했습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/mypage-103` -> `dev`
- close #103 

<br/>

## 🔥 트러블 슈팅 (선택)

### 문제 1: 시간 비교 시 타입 불일치 오류
- `Expressions.currentTimestamp()`와 같은 `DateTimeExpression`을 사용할 때, `LocalDateTime`과 `java.util.Date` 타입 불일치 오류가 발생했습니다.

### 해결 1:
- 한국 시간(KST)으로 현시점을 조회하여 비교하는 방식으로 문제를 해결했습니다.
- `LocalDateTime.now(ZoneOffset.ofHours(9))`를 사용하여 현지 시간 기준으로 비교를 진행했습니다.

### 문제 2: `DateTimeTemplate.create()` 메서드 오류
- `DateTimeTemplate.create()` 메서드를 사용할 수 없는 오류가 발생했습니다.

### 해결 2:
- `DateTimeExpression<LocalDateTime>` 타입을 사용해야 했기 때문에, `DateTimeTemplate.create()`를 대체하여 직접 `LocalDateTime.now(ZoneOffset.ofHours(9))`를 사용하여 해결했습니다.
