### PR TITLE
[Feat] 회원 탈퇴 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/repository/AttendanceRepository.java
@@ -20,4 +20,6 @@ public interface AttendanceRepository extends JpaRepository<Attendance, Long> {
 
     List<Attendance> findAllByUserAndPlanOpened(User user, boolean opened);
 
+    void deleteByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReader.java
@@ -12,8 +12,6 @@ public interface AttendanceReader {
 
     List<Attendance> getAttendanceList(Plan plan);
 
-    void delete(Attendance attendance);
-
     boolean existAttendance(User user, Plan plan);
 
     int getParticipantsCount(Plan plan);

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceReaderImpl.java
@@ -32,12 +32,6 @@ public class AttendanceReaderImpl implements AttendanceReader {
         return attendanceRepository.findAllByPlan(plan);
     }
 
-    @Override
-    public void delete(Attendance attendance) {
-
-        attendanceRepository.delete(attendance);
-    }
-
     /**
      * 일정 참여 내역 조회
      *

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStore.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStore.java
@@ -11,4 +11,6 @@ public interface AttendanceStore {
 
     void quitPlan(User user, Plan plan);
 
+    void deleteAllByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/attendance/service/AttendanceStoreImpl.java
@@ -71,6 +71,14 @@ public class AttendanceStoreImpl implements AttendanceStore {
 
     }
 
+    // 일정 참여 내역 삭제
+    @Override
+    public void deleteAllByUser(User user) {
+
+        attendanceRepository.deleteByUser(user);
+    }
+
+
     @Transactional
     private void updatePlanStatus(Plan plan, int participants) {
         // 최소 인원 충족 시 개설 확정

--- a/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
+++ b/src/main/java/com/wemo/backend/domain/image/repository/ImageRepository.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.image.repository;
 
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -10,5 +11,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     Image findByEntityIdAndEntityTypeAndMainIsTrue(Long entityId, Image.EntityType entityType);
 
     List<Image> findAllByEntityIdAndEntityType(Long entityId, Image.EntityType entityType);
+
+    List<Image> findAllByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReader.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.image.service;
 
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.user.entity.User;
 
 import java.util.List;
 
@@ -10,6 +11,6 @@ public interface ImageReader {
 
     List<String> getImageList(Long entityId, Image.EntityType entityType);
 
-    void deleteImage(Long entityId, Image.EntityType entityType);
+    List<Image> getImageListByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageReaderImpl.java
@@ -2,7 +2,7 @@ package com.wemo.backend.domain.image.service;
 
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.repository.ImageRepository;
-import jakarta.transaction.Transactional;
+import com.wemo.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -36,11 +36,9 @@ public class ImageReaderImpl implements ImageReader {
     }
 
     @Override
-    @Transactional
-    public void deleteImage(Long entityId, Image.EntityType entityType) {
+    public List<Image> getImageListByUser(User user) {
 
-        List<Image> imageList = imageRepository.findAllByEntityIdAndEntityType(entityId, entityType);
-        imageRepository.deleteAll(imageList); // 이미지 삭제
+        return imageRepository.findAllByUser(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/image/service/ImageStoreImpl.java
@@ -75,8 +75,8 @@ public class ImageStoreImpl implements ImageStore {
     @Override
     public void deleteImage(Long entityId, Image.EntityType entityType) {
         // 기존 이미지 삭제
-        List<Image> allByEntityIdAndEntityType = imageRepository.findAllByEntityIdAndEntityType(entityId, entityType);
-        imageRepository.deleteAll(allByEntityIdAndEntityType);
+        List<Image> imageList = imageRepository.findAllByEntityIdAndEntityType(entityId, entityType);
+        imageRepository.deleteAll(imageList);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
+++ b/src/main/java/com/wemo/backend/domain/like/repository/LikeRepository.java
@@ -17,4 +17,6 @@ public interface LikeRepository extends JpaRepository<Likes, Long> {
 
     List<Likes> findAllByUser(User user);
 
+    void deleteByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeReader.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeReader.java
@@ -12,6 +12,6 @@ public interface LikeReader {
 
     void validateLikeToDelete(User user, Plan plan);
 
-    List<Likes> getLikeCountByUser(User user);
+    List<Likes> getLikesByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeReaderImpl.java
@@ -10,11 +10,12 @@ import org.springframework.stereotype.Component;
 
 import java.util.List;
 
-import static com.wemo.backend.global.exception.ErrorCode.*;
+import static com.wemo.backend.global.exception.ErrorCode.ALREADY_LIKED_PLAN;
+import static com.wemo.backend.global.exception.ErrorCode.LIKE_NOT_FOUND;
 
 @Component
 @RequiredArgsConstructor
-public class LikeReaderImpl implements LikeReader{
+public class LikeReaderImpl implements LikeReader {
 
     private final LikeRepository likeRepository;
 
@@ -32,7 +33,7 @@ public class LikeReaderImpl implements LikeReader{
     }
 
     @Override
-    public List<Likes> getLikeCountByUser(User user) {
+    public List<Likes> getLikesByUser(User user) {
 
         return likeRepository.findAllByUser(user);
     }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeServiceImpl.java
@@ -40,7 +40,7 @@ public class LikeServiceImpl implements LikeService {
         // 이미 좋아요를 누른 일정이라면 예외 반환
         likeReader.validateLike(user, plan);
 
-        likeStore.storeLike(user, plan);
+        likeStore.addLike(user, plan);
 
         log.info("사용자 {}가 일정 id {}에 좋아요를 눌렀습니다.", user.getEmail(), plan.getId());
 
@@ -64,7 +64,7 @@ public class LikeServiceImpl implements LikeService {
         // 좋아요를 누르지 않은 일정이라면 예외 반환
         likeReader.validateLikeToDelete(user, plan);
 
-        likeStore.deleteLike(user, plan);
+        likeStore.removeLike(user, plan);
 
         log.info("사용자 {}가 일정 id {}에 누른 좋아요를 취소했습니다.", user.getEmail(), plan.getId());
 

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeStore.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeStore.java
@@ -5,8 +5,10 @@ import com.wemo.backend.domain.user.entity.User;
 
 public interface LikeStore {
 
-    void storeLike(User user, Plan plan);
+    void addLike(User user, Plan plan);
 
-    void deleteLike(User user, Plan plan);
+    void removeLike(User user, Plan plan);
+
+    void deleteAllByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeStoreImpl.java
@@ -16,7 +16,7 @@ public class LikeStoreImpl implements LikeStore {
 
     @Override
     @Transactional
-    public void storeLike(User user, Plan plan) {
+    public void addLike(User user, Plan plan) {
 
         Likes like = Likes.builder()
                 .user(user)
@@ -27,11 +27,17 @@ public class LikeStoreImpl implements LikeStore {
     }
 
     @Override
-    public void deleteLike(User user, Plan plan) {
+    public void removeLike(User user, Plan plan) {
 
         Likes like = likeRepository.findByUserAndPlan(user, plan);
 
         likeRepository.delete(like);
+    }
+
+    @Override
+    public void deleteAllByUser(User user) {
+
+        likeRepository.deleteByUser(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingDetailResponse.java
@@ -52,6 +52,12 @@ public class MeetingDetailResponse {
 
     private List<ReviewListInfo> reviewList;
 
+    @JsonProperty("isJoined")
+    public boolean getIsJoined() {
+
+        return isJoined;
+    }
+
     public static MeetingDetailResponse fromEntity(Meeting meeting, List<String> meetingImage, boolean isJoined, int memberCount, List<UserListInfo> userListInfoList, int planCounts, List<PlanListInfo> planListInfoList, int reviewCounts, double reviewAverage, List<ReviewListInfo> reviewListInfoList) {
 
         return MeetingDetailResponse.builder()

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingRepository.java
@@ -1,12 +1,13 @@
 package com.wemo.backend.domain.meeting.repository;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface MeetingRepository extends JpaRepository<Meeting, Long>, MeetingQueryDsl {
 
-    Optional<Meeting> findByIdAndDeletedAtIsNull(Long meetingId);
+    List<Meeting> findAllByUserAndDeletedAtIsNull(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReader.java
@@ -1,12 +1,14 @@
 package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
-import com.wemo.backend.domain.meetingMember.entity.MeetingMember;
+import com.wemo.backend.domain.user.entity.User;
 
 import java.util.List;
 
 public interface MeetingReader {
 
     Meeting getMeeting(Long meetingId);
+
+    List<Meeting> getMeetingListByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingReaderImpl.java
@@ -2,9 +2,12 @@ package com.wemo.backend.domain.meeting.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meeting.repository.MeetingRepository;
+import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 import static com.wemo.backend.global.exception.ErrorCode.MEETING_NOT_FOUND;
 
@@ -17,9 +20,15 @@ public class MeetingReaderImpl implements MeetingReader {
     @Override
     public Meeting getMeeting(Long meetingId) {
 
-        return meetingRepository.findByIdAndDeletedAtIsNull(meetingId).orElseThrow(
+        return meetingRepository.findById(meetingId).orElseThrow(
                 () -> new CustomException(MEETING_NOT_FOUND)
         );
+    }
+
+    @Override
+    public List<Meeting> getMeetingListByUser(User user) {
+
+        return meetingRepository.findAllByUserAndDeletedAtIsNull(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingUtilServiceImpl.java
@@ -4,8 +4,10 @@ import com.wemo.backend.domain.attendance.service.AttendanceReader;
 import com.wemo.backend.domain.comm.CommUtilService;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.image.service.ImageReader;
+import com.wemo.backend.domain.image.service.ImageStore;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meetingMember.service.MeetingMemberReader;
+import com.wemo.backend.domain.meetingMember.service.MeetingMemberStore;
 import com.wemo.backend.domain.plan.dto.PlanListInfo;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.service.PlanReader;
@@ -33,9 +35,13 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
 
     private final ImageReader imageReader;
 
+    private final ImageStore imageStore;
+
     private final MeetingMemberReader meetingMemberReader;
 
     private final AttendanceReader attendanceReader;
+
+    private final MeetingMemberStore meetingMemberStore;
 
     private static final Comparator<UserListInfo> USER_DATE_DESC = Comparator.comparing(UserListInfo::getCreatedAt).reversed();
     private static final Comparator<PlanListInfo> PLAN_DATE_DESC = Comparator.comparing(PlanListInfo::getDateTime).reversed();
@@ -99,6 +105,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
         for (Plan plan : plans) {
             deleteReviews(plan);
             deletePlanImages(plan);
+            plan.softDelete();
         }
     }
 
@@ -113,7 +120,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
 
         for (Review review : reviews) {
             deleteReviewImages(review);
-            reviewReader.delete(review);
+            review.softDelete();
         }
     }
 
@@ -124,7 +131,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
      */
     private void deleteReviewImages(Review review) {
 
-        imageReader.deleteImage(review.getId(), Image.EntityType.REVIEW);
+        imageStore.deleteImage(review.getId(), Image.EntityType.REVIEW);
     }
 
     /**
@@ -134,7 +141,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
      */
     private void deletePlanImages(Plan plan) {
 
-        imageReader.deleteImage(plan.getId(), Image.EntityType.PLAN);
+        imageStore.deleteImage(plan.getId(), Image.EntityType.PLAN);
     }
 
     /**
@@ -146,7 +153,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
     public void deleteMembers(Meeting meeting) {
 
         meetingMemberReader.getMemberListByMeeting(meeting)
-                .forEach(meetingMemberReader::delete);
+                .forEach(meetingMemberStore::deleteMeetingMember);
     }
 
     /**
@@ -157,7 +164,7 @@ public class MeetingUtilServiceImpl implements MeetingUtilService {
     @Override
     public void deleteMeetingImages(Meeting meeting) {
 
-        imageReader.deleteImage(meeting.getId(), Image.EntityType.MEETING);
+        imageStore.deleteImage(meeting.getId(), Image.EntityType.MEETING);
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/meetingMember/repository/MeetingMemberRepository.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/repository/MeetingMemberRepository.java
@@ -16,4 +16,8 @@ public interface MeetingMemberRepository extends JpaRepository<MeetingMember, Lo
 
     Optional<MeetingMember> findByUserAndMeeting(User user, Meeting meeting);
 
+    List<MeetingMember> findAllByUser(User user);
+
+    void deleteByUser(User user);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberReader.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberReader.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.meetingMember.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meetingMember.entity.MeetingMember;
+import com.wemo.backend.domain.user.entity.User;
 
 import java.util.List;
 
@@ -9,6 +10,7 @@ public interface MeetingMemberReader {
 
     List<MeetingMember> getMemberListByMeeting(Meeting meeting);
 
-    void delete(MeetingMember meetingMember);
+
+    List<MeetingMember> getJoinedMeetingsByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberReaderImpl.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.meetingMember.service;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.meetingMember.entity.MeetingMember;
 import com.wemo.backend.domain.meetingMember.repository.MeetingMemberRepository;
+import com.wemo.backend.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,9 +23,9 @@ public class MeetingMemberReaderImpl implements MeetingMemberReader {
     }
 
     @Override
-    public void delete(MeetingMember meetingMember) {
+    public List<MeetingMember> getJoinedMeetingsByUser(User user) {
 
-        meetingMemberRepository.delete(meetingMember);
+        return meetingMemberRepository.findAllByUser(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStore.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStore.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.meetingMember.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meetingMember.entity.MeetingMember;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.stereotype.Service;
 
@@ -14,5 +15,9 @@ public interface MeetingMemberStore {
     void deleteMember(User user, Meeting meeting);
 
     boolean isAlreadyJoined(User user, Meeting meeting);
+
+    void deleteAllByUser(User user);
+
+    void deleteMeetingMember(MeetingMember meetingMember);
 
 }

--- a/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meetingMember/service/MeetingMemberStoreImpl.java
@@ -62,6 +62,20 @@ public class MeetingMemberStoreImpl implements MeetingMemberStore {
         return meetingMemberRepository.existsByUserAndMeeting(user, meeting);
     }
 
+    // 가입 내역 삭제
+    @Override
+    public void deleteAllByUser(User user) {
+
+        meetingMemberRepository.deleteByUser(user);
+    }
+
+    @Override
+    public void deleteMeetingMember(MeetingMember meetingMember) {
+
+        meetingMemberRepository.delete(meetingMember);
+    }
+
+
     // 모임 회원 저장
     private void saveMeetingMember(User user, Meeting meeting) {
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/PlanRepository.java
@@ -4,12 +4,15 @@ import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.querydsl.PlanCursorQueryDsl;
 import com.wemo.backend.domain.plan.repository.querydsl.PlanQueryDsl;
+import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface PlanRepository extends JpaRepository<Plan, Long>, PlanCursorQueryDsl, PlanQueryDsl {
 
-    List<Plan> findAllByMeeting(Meeting meeting);
+    List<Plan> findAllByMeetingAndDeletedAtIsNull(Meeting meeting);
+
+    List<Plan> findAllByUserAndDeletedAtIsNull(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReader.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.plan.service;
 
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.user.entity.User;
 
 import java.util.List;
 
@@ -11,6 +12,6 @@ public interface PlanReader {
 
     List<Plan> getPlanByMeeting(Meeting meeting);
 
-    void delete(Plan plan);
+    List<Plan> getPlanListByUser(User user);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanReaderImpl.java
@@ -3,6 +3,7 @@ package com.wemo.backend.domain.plan.service;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
+import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -29,14 +30,13 @@ public class PlanReaderImpl implements PlanReader {
     @Override
     public List<Plan> getPlanByMeeting(Meeting meeting) {
 
-        return planRepository.findAllByMeeting(meeting);
+        return planRepository.findAllByMeetingAndDeletedAtIsNull(meeting);
     }
 
     @Override
-    public void delete(Plan plan) {
+    public List<Plan> getPlanListByUser(User user) {
 
-        planRepository.delete(plan);
-
+        return planRepository.findAllByUserAndDeletedAtIsNull(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStore.java
@@ -10,4 +10,6 @@ public interface PlanStore {
 
     Plan storePlan(PlanCreateRequest request, District district, User user, Meeting meeting);
 
+    void delete(Plan plan);
+
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanStoreImpl.java
@@ -47,4 +47,11 @@ public class PlanStoreImpl implements PlanStore {
         return plan;
     }
 
+    @Override
+    public void delete(Plan plan) {
+
+        planRepository.delete(plan);
+
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
+++ b/src/main/java/com/wemo/backend/domain/review/repository/ReviewRepository.java
@@ -7,14 +7,17 @@ import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ReviewRepository extends JpaRepository<Review, Long>, ReviewQueryDsl {
 
     boolean existsByUserAndPlan(User user, Plan plan);
 
+    Optional<Review> findByIdAndDeletedAtIsNull(Long reviewId);
+
     List<Review> findAllByPlan(Plan plan);
 
-    List<Review> findAllByUser(User user);
+    List<Review> findAllByUserAndDeletedAtIsNull(User user);
 
     void deleteAllByPlan(Plan plan);
 

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReader.java
@@ -10,8 +10,6 @@ public interface ReviewReader {
 
     List<Review> getReviewByPlan(Plan plan);
 
-    void delete(Review review);
-
     Review getReview(Long reviewId);
 
     void validateReview(User user, Review review);

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewReaderImpl.java
@@ -20,23 +20,17 @@ public class ReviewReaderImpl implements ReviewReader {
     private final ReviewRepository reviewRepository;
 
     @Override
+    public Review getReview(Long reviewId) {
+
+        return reviewRepository.findByIdAndDeletedAtIsNull(reviewId).orElseThrow(
+                () -> new CustomException(REVIEW_NOT_FOUND)
+        );
+    }
+
+    @Override
     public List<Review> getReviewByPlan(Plan plan) {
 
         return reviewRepository.findAllByPlan(plan);
-    }
-
-    @Override
-    public void delete(Review review) {
-
-        reviewRepository.delete(review);
-    }
-
-    @Override
-    public Review getReview(Long reviewId) {
-
-        return reviewRepository.findById(reviewId).orElseThrow(
-                () -> new CustomException(REVIEW_NOT_FOUND)
-        );
     }
 
     @Override
@@ -48,7 +42,7 @@ public class ReviewReaderImpl implements ReviewReader {
     @Override
     public List<Review> getReviewByUser(User user) {
 
-        return reviewRepository.findAllByUser(user);
+        return reviewRepository.findAllByUserAndDeletedAtIsNull(user);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserDashboardController.java
@@ -145,4 +145,14 @@ public class UserDashboardController {
 
     }
 
+    @Operation(summary = "회원 탈퇴", description = "회원 탈퇴합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "정상적으로 탈퇴 처리되었습니다.")
+    })
+    @RequestMapping(value = "/withdraw", method = RequestMethod.DELETE)
+    public ResponseEntity<SuccessResponse<String>> withdraw(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithNoData(userService.withdraw(userDetails.getUsername())));
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/entity/User.java
+++ b/src/main/java/com/wemo/backend/domain/user/entity/User.java
@@ -80,4 +80,9 @@ public class User extends Timestamped {
 
     }
 
+    public void setDeletedUserNickname() {
+
+        this.nickname = "탈퇴한 사용자";
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -39,4 +39,6 @@ public interface UserService {
 
     UserPlanPagingResponse getMyPlanListV2(String email, Pageable pageable);
 
+    String withdraw(String email);
+
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.user.service;
 
 import com.wemo.backend.domain.attendance.entity.Attendance;
 import com.wemo.backend.domain.attendance.service.AttendanceReader;
+import com.wemo.backend.domain.attendance.service.AttendanceStore;
 import com.wemo.backend.domain.auth.UserAuth;
 import com.wemo.backend.domain.auth.token.entity.RefreshToken;
 import com.wemo.backend.domain.auth.token.repository.RefreshTokenRepository;
@@ -9,6 +10,12 @@ import com.wemo.backend.domain.auth.token.service.AccessTokenManager;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.like.entity.Likes;
 import com.wemo.backend.domain.like.service.LikeReader;
+import com.wemo.backend.domain.like.service.LikeStore;
+import com.wemo.backend.domain.meeting.entity.Meeting;
+import com.wemo.backend.domain.meeting.service.MeetingReader;
+import com.wemo.backend.domain.meetingMember.service.MeetingMemberStore;
+import com.wemo.backend.domain.plan.entity.Plan;
+import com.wemo.backend.domain.plan.service.PlanReader;
 import com.wemo.backend.domain.review.entity.Review;
 import com.wemo.backend.domain.review.service.ReviewReader;
 import com.wemo.backend.domain.user.dto.*;
@@ -40,8 +47,13 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final AttendanceReader attendanceReader;
     private final LikeReader likeReader;
+    private final LikeStore likeStore;
     private final ReviewReader reviewReader;
     private final AccessTokenManager accessTokenManager;
+    private final MeetingReader meetingReader;
+    private final PlanReader planReader;
+    private final MeetingMemberStore meetingMemberStore;
+    private final AttendanceStore attendanceStore;
 
     /**
      * 이메일 중복 검사
@@ -122,7 +134,7 @@ public class UserServiceImpl implements UserService {
         User user = userReader.getUserByEmail(email);
 
         List<Attendance> joinedPlanList = attendanceReader.getAttendanceByUser(user);
-        List<Likes> likedPlanList = likeReader.getLikeCountByUser(user);
+        List<Likes> likedPlanList = likeReader.getLikesByUser(user);
         List<Review> reviewList = reviewReader.getReviewByUser(user);
 
         log.info("사용자 {}의 회원 정보가 반환되었습니다.", user.getEmail());
@@ -254,6 +266,37 @@ public class UserServiceImpl implements UserService {
     public UserPlanPagingResponse getMyPlanListV2(String email, Pageable pageable) {
 
         return new UserPlanPagingResponse(userRepository.getMyPlanListV2(email, pageable));
+    }
+
+    /**
+     * 회원 탈퇴 기능
+     *
+     * @param email 사용자 이메일
+     * @return 응답 메세지
+     */
+    @Override
+    @Transactional
+    public String withdraw(String email) {
+
+        // 유저 객체 조회 및 softDelete 처리
+        User user = userReader.getUserByEmail(email);
+        user.softDelete();
+        user.setDeletedUserNickname();
+
+        // 유저가 생성한 데이터 softDelete 처리 (forEach 사용하여 간결화)
+        meetingReader.getMeetingListByUser(user).forEach(Meeting::softDelete);
+        planReader.getPlanListByUser(user).forEach(Plan::softDelete);
+        reviewReader.getReviewByUser(user).forEach(Review::softDelete);
+
+        // 모임 가입 내역, 일정 참여 내역, 좋아요 내역 batch delete 처리
+        meetingMemberStore.deleteAllByUser(user);
+        attendanceStore.deleteAllByUser(user);
+        likeStore.deleteAllByUser(user);
+
+        // TODO : 이미지 삭제 (관련 오류 발생 가능성 있음 → 기본 이미지 설정 고려)
+        // imageStore.deleteAllByUser(user);
+
+        return "정상적으로 탈퇴 처리되었습니다.";
     }
 
     private String getTokenFromCookie(HttpServletRequest request, String tokenName) {


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 회원 탈퇴 기능을 구현하였습니다.
- 회원 정보와 회원이 생성한 모임, 일정, 후기 데이터는 **softDelete** 처리하였고, 그 외 유저와 관련된 데이터(가입 내역, 참여 내역, 좋아요 내역 등)는 **물리적 삭제** 처리하였습니다.
- 이미지 데이터의 경우, 추후 모임, 일정, 후기 데이터 조회 시 오류 발생 가능성을 고려해 삭제 처리하지 않았습니다. (S3 이미지 삭제와 함께 추후 처리 예정입니다.)
- **삭제 관련 메서드**의 위치를 `Reader` 인터페이스에서 `Store` 인터페이스로 이동시켰습니다.

<br/>

## 🌱 반영 브랜치
- `feat/user-withdraw-119` -> `dev`
- close #119

<br/>

## 🔥 트러블 슈팅 (선택)
- **이미지 삭제 처리**: 회원 탈퇴 시 관련된 이미지 데이터를 삭제해야 하는 부분에서, 모임, 일정, 후기 데이터 조회 시 이미지 오류가 발생할 가능성을 고려했습니다. 따라서 이미지는 별도로 S3에서 삭제할 수 있도록 **추후 처리 예정**으로 남겨두었습니다.

<br/>
