### PR TITLE
[Refactor] 유저 후기 관련 기능 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserReviewListResponse.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -15,7 +16,9 @@ public class UserReviewListResponse {
 
     private String comment;
 
-    private String reviewImagePath;
+    private String planImagePath;
+
+    private List<String> reviewImages;
 
     private LocalDateTime createdAt;
 
@@ -30,5 +33,25 @@ public class UserReviewListResponse {
     private String category;
 
     private String address;
+
+    public UserReviewListResponse(Long reviewId, int score, String comment, String planImagePath, LocalDateTime createdAt, LocalDateTime updatedAt, Long planId, String planName, LocalDateTime dateTime, String category, String address) {
+
+        this.reviewId = reviewId;
+        this.score = score;
+        this.comment = comment;
+        this.planImagePath = planImagePath;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+        this.planId = planId;
+        this.planName = planName;
+        this.dateTime = dateTime;
+        this.category = category;
+        this.address = address;
+    }
+
+    public void setReviewImages(List<String> reviewImages) {
+
+        this.reviewImages = reviewImages;
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -258,10 +258,10 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 Expressions.as(
                                         queryFactory.select(image.fileUrl)
                                                 .from(image)
-                                                .where(image.entityId.eq(review.id),
-                                                        image.entityType.eq(Image.EntityType.REVIEW),
+                                                .where(image.entityId.eq(plan.id),
+                                                        image.entityType.eq(Image.EntityType.PLAN),
                                                         image.main.eq(true)),
-                                        "reviewImagePath"
+                                        "planImagePath"
                                 ),
                                 review.createdAt,
                                 review.updatedAt,
@@ -287,6 +287,18 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .limit(pageable.getPageSize())
                 .offset(pageable.getOffset())
                 .fetch();
+
+        // 각 리뷰별로 이미지 목록을 별도로 처리
+        for (UserReviewListResponse review : reviewListResponses) {
+            List<String> reviewImages = queryFactory
+                    .select(image.fileUrl)
+                    .from(image)
+                    .where(image.entityId.eq(review.getReviewId()), // reviewId로 이미지를 필터링
+                            image.entityType.eq(Image.EntityType.REVIEW))
+                    .fetch();
+
+            review.setReviewImages(reviewImages); // 각 리뷰에 해당하는 이미지 목록 설정
+        }
 
         // 총 개수 조회
         long total = Optional.ofNullable(
@@ -337,18 +349,19 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 plan.updatedAt
                         )
                 )
-                .from(attendance) // attendance 테이블을 from 절에서 시작
+                .from(attendance)
                 .leftJoin(attendance.plan, plan)
                 .leftJoin(plan.meeting, meeting)
                 .leftJoin(meeting.category, category)
                 .leftJoin(attendance.user, user)
-                .leftJoin(review).on(review.plan.id.eq(plan.id)) // review와 plan을 조인
+                .leftJoin(review).on(review.plan.id.eq(plan.id))
                 .where(
-                        attendance.user.email.eq(email) // 이메일 조건
-                                .and(attendance.reviewed.eq(false)) // 후기 미작성
-                                .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
+                        attendance.user.email.eq(email), // 유저 참석 확인
+                        attendance.reviewed.eq(false), // 후기 미작성 필터
+                        plan.dateTime.before(LocalDateTime.now()), // 지난 일정만 조회
+                        plan.deletedAt.isNull(), // 삭제되지 않은 일정만 조회
+                        plan.meeting.deletedAt.isNull() // 삭제되지 않은 모임만 조회
                 )
-                .where(review.plan.meeting.deletedAt.isNull()) // 삭제된 모임의 필터링
                 .groupBy(plan.id)
                 .orderBy(plan.createdAt.desc());
 
@@ -361,18 +374,19 @@ public class UserQueryDslImpl implements UserQueryDsl {
         long total = Optional.ofNullable(
                 queryFactory
                         .select(plan.count())
-                        .from(attendance) // attendance 테이블을 from 절에서 시작
+                        .from(attendance)
                         .leftJoin(attendance.plan, plan)
                         .leftJoin(plan.meeting, meeting)
                         .leftJoin(meeting.category, category)
                         .leftJoin(attendance.user, user)
-                        .leftJoin(review).on(review.plan.id.eq(plan.id)) // review와 plan을 조인
+                        .leftJoin(review).on(review.plan.id.eq(plan.id))
                         .where(
-                                attendance.user.email.eq(email) // 이메일 조건
-                                        .and(attendance.reviewed.eq(false)) // 후기 미작성
-                                        .and(plan.dateTime.before(LocalDateTime.now())) // 일정이 지남
+                                attendance.user.email.eq(email), // 유저 참석 확인
+                                attendance.reviewed.eq(false), // 후기 미작성 필터
+                                plan.dateTime.before(LocalDateTime.now()), // 지난 일정만 조회
+                                plan.deletedAt.isNull(), // 삭제되지 않은 일정만 조회
+                                plan.meeting.deletedAt.isNull() // 삭제되지 않은 모임만 조회
                         )
-                        .where(review.plan.meeting.deletedAt.isNull()) // 삭제된 모임의 필터링
                         .fetchOne()
         ).orElse(0L);
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 내가 쓴 후기 목록 조회 시 응답 데이터 수정하였습니다. (planImagePath 추가, 후기 이미지 배열 형태로 변경)
- 후기 작성 가능한 일정 조회 시 후기가 존재하지 않는 일정도 조회될 수 있도록 조건절 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/mypage-103` -> `dev`
- close #103 

<br/>

## 🔥 트러블 슈팅 (선택)

### 🤔 문제
- QueryDSL의 `LEFT JOIN`을 사용할 때 `WHERE` 절이 예상치 못한 필터링을 유발하는 문제 발생  
- `LEFT JOIN`은 기준 테이블(attendance)의 데이터를 모두 가져오지만, `WHERE` 절에서 `review.plan.meeting.deletedAt.isNull()` 조건을 추가하면  
  **review가 없는 일정(plan)은 조회되지 않는 문제**가 발생  


### ✅ **문제 원인**
- `LEFT JOIN review`를 하면 `review`가 없는 경우 `NULL`이 반환됨
- `WHERE review.plan.meeting.deletedAt.isNull()` 조건이 있으면, `review`가 `NULL`인 행은 조건을 확인할 수 없어서 제외됨
- 즉, **리뷰가 없는 일정이 조회되지 않는 문제 발생**


### 🛠 **해결 방법**
✅ 해결 방법 요약: `WHERE review.plan.meeting.deletedAt.isNull()`을 제거하고, `plan.meeting.deletedAt.isNull()`로 변경하여 review가 없는 일정도 조회되도록 수정

- `WHERE` 절에서 `review.plan.meeting.deletedAt.isNull()` 조건을 제거하고, 대신 `plan.meeting.deletedAt.isNull()`을 적용  
- 이렇게 하면 **삭제되지 않은 모임만 필터링하면서, review가 없는 일정도 정상적으로 조회됨**

```java
.where(
    attendance.user.email.eq(email),
    attendance.reviewed.eq(false),
    plan.dateTime.before(LocalDateTime.now()),
    plan.deletedAt.isNull(), // 삭제되지 않은 일정만 조회
    plan.meeting.deletedAt.isNull() // 삭제되지 않은 모임만 조회
)
