### PR TITLE
[Refactor] 모임 목록 조회 기능 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.auth;
 
 import com.wemo.backend.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 public interface UserAuth {
@@ -9,6 +10,6 @@ public interface UserAuth {
 
     String saveRefreshTokenToRedis(User user);
 
-    void generateHeaderTokens(User user, HttpServletResponse response);
+    void generateHeaderTokens(User user, HttpServletRequest request, HttpServletResponse response);
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
@@ -4,6 +4,7 @@ import com.wemo.backend.domain.auth.token.service.AccessTokenManager;
 import com.wemo.backend.domain.auth.token.service.JwtTokenUtils;
 import com.wemo.backend.domain.auth.token.service.RefreshTokenManager;
 import com.wemo.backend.domain.user.entity.User;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,12 +53,12 @@ public class UserAuthImpl implements UserAuth {
      * @param user 유저 객체
      */
     @Override
-    public void generateHeaderTokens(User user, HttpServletResponse response) {
+    public void generateHeaderTokens(User user, HttpServletRequest request, HttpServletResponse response) {
 
         String accessToken = getAccessToken(user);
         String refreshToken = saveRefreshTokenToRedis(user);
 
-        accessTokenManager.setAccessTokenInCookie(accessToken, response);
+        accessTokenManager.setAccessTokenInCookie(accessToken, request, response);
         refreshTokenManager.setRefreshTokenInCookie(refreshToken, response);
         log.info("accessToken 및 refreshToken 생성 완료");
         log.info("refreshToken 쿠키로 전달 완료");

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.auth.token.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
@@ -17,18 +18,25 @@ public class AccessTokenManager {
      *
      * @param accessToken accessToken 값
      */
-    public void setAccessTokenInCookie(String accessToken, HttpServletResponse response) {
+    public void setAccessTokenInCookie(String accessToken, HttpServletRequest request, HttpServletResponse response) {
 
         // 현재 시간 + 5분
         Date expiryDate = new Date(System.currentTimeMillis() + 5 * 60 * 1000);
 
+        // domain 을 동적으로 설정: 로컬에서는 "localhost", 배포 환경에서는 ".we-mo.shop"
+        String domain = request.getServerName().contains("localhost") ? "localhost" : ".we-mo.shop";
+
+        // 로컬 환경에서는 Secure 비활성화, 배포 환경에서는 활성화
+        boolean isLocal = request.getServerName().contains("localhost");
+        boolean isSecure = !isLocal;
+
         // 쿠키 생성
         ResponseCookie cookie = ResponseCookie.from("accessToken", accessToken)
-                .domain(".we-mo.shop") // 임시로 도메인 지정
-                .sameSite("None")
-                .secure(true)
-                .httpOnly(true)
-                .path("/")
+                .domain(domain)          // 도메인 동적 설정
+                .sameSite("None")         // SameSite 설정
+                .secure(isSecure)         // secure 값 동적 설정
+                .httpOnly(true)           // httpOnly 설정
+                .path("/")                // 경로 설정
                 .build();
 
         // 쿠키 설정 후 만료 시간을 Expires 헤더에 추가

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -107,7 +107,7 @@ public class RefreshTokenManager {
         }
 
         String newAccessToken = jwtTokenUtils.generateAccessToken(email);
-        accessTokenManager.setAccessTokenInCookie(newAccessToken, response);
+        accessTokenManager.setAccessTokenInCookie(newAccessToken, request, response);
 
         log.info("토큰 생성 후 헤더에 담기 완료!");
     }

--- a/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/controller/MeetingController.java
@@ -142,11 +142,11 @@ public class MeetingController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "요청한 모임 목록이 반환되었습니다.")
     })
-    @RequestMapping(value = "", method = RequestMethod.GET)
-    public ResponseEntity<SuccessResponse<MeetingCursorPagingResponse>> getMeetingList(@RequestParam(required = false) Long cursor,
-                                                                                       @RequestParam(required = false, defaultValue = "10") int size,
-                                                                                       @RequestParam(required = false) Long categoryId,
-                                                                                       @RequestParam(required = false) String sort) {
+    @RequestMapping(value = "/v1", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingCursorPagingResponse>> getMeetingListV1(@RequestParam(required = false) Long cursor,
+                                                                                         @RequestParam(required = false, defaultValue = "10") int size,
+                                                                                         @RequestParam(required = false) Long categoryId,
+                                                                                         @RequestParam(required = false) String sort) {
 
         MeetingCursorPagingResponse response = meetingService.getMeetingList(cursor, size, categoryId, sort);
         return ResponseEntity.ok(SuccessResponse.successWithData(response));
@@ -162,6 +162,20 @@ public class MeetingController {
     public ResponseEntity<SuccessResponse<String>> joinCancelMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails, @PathVariable Long meetingId) {
 
         return ResponseEntity.ok(SuccessResponse.successWithNoData(meetingService.joinCancelMeeting(userDetails.getUsername(), meetingId)));
+    }
+
+    @Operation(summary = "모임 목록 조회 v2", description = "회원 또는 비회원이 요청하는 모임의 목록을 반환합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 모임 목록이 반환되었습니다.")
+    })
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<MeetingCursorPagingResponse>> getMeetingListV2(@RequestParam(required = false) Long cursor,
+                                                                                         @RequestParam(required = false, defaultValue = "10") int size,
+                                                                                         @RequestParam(required = false) Long categoryId,
+                                                                                         @RequestParam(required = false) String sort) {
+
+        MeetingCursorPagingResponse response = meetingService.getMeetingListV2(cursor, size, categoryId, sort);
+        return ResponseEntity.ok(SuccessResponse.successWithData(response));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCursorPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCursorPagingResponse.java
@@ -11,16 +11,28 @@ public class MeetingCursorPagingResponse {
 
     private int meetingCount;
 
-    private List<MeetingListResponse> meetingList;
+    private List<?> meetingList;
 
     private Long nextCursor;
 
-    public MeetingCursorPagingResponse(List<MeetingListResponse> meetingListResponses, int meetingCount) {
+    public MeetingCursorPagingResponse(List<?> meetingListResponses, int meetingCount) {
 
         this.meetingCount = meetingCount;
         this.meetingList = meetingListResponses;
-        this.nextCursor = meetingListResponses.isEmpty() ? null : meetingListResponses.get(meetingListResponses.size() - 1).getMeetingId();
+        this.nextCursor = meetingListResponses.isEmpty() ? null : getLastMeetingId(meetingListResponses);
+    }
 
+    private static Long getLastMeetingId(List<?> meetingListResponses) {
+
+        if (!meetingListResponses.isEmpty()) {
+            Object lastItem = meetingListResponses.get(meetingListResponses.size() - 1);
+            if (lastItem instanceof MeetingListResponse) {
+                return ((MeetingListResponse) lastItem).getMeetingId();
+            } else if (lastItem instanceof MeetingListResponseV2) {
+                return ((MeetingListResponseV2) lastItem).getMeetingId();
+            }
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListPlanListResponse.java
@@ -1,0 +1,33 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MeetingListPlanListResponse {
+
+    private Long planId;
+
+    private Long meetingId;
+
+    private String planName;
+
+    private LocalDateTime dateTime;
+
+    private Long participants;
+
+    private int capacity;
+
+    private String planImagePath;
+
+    @JsonProperty("isOpened")
+    private boolean isOpened;
+
+    @JsonProperty("isFulled")
+    private boolean isFulled;
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponseV2.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponseV2.java
@@ -1,0 +1,45 @@
+package com.wemo.backend.domain.meeting.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MeetingListResponseV2 {
+
+    private String email;
+
+    private Long meetingId;
+
+    private String meetingName;
+
+    private String description;
+
+    private String meetingImagePath;
+
+    private Long memberCount;
+
+    private String category;
+
+    private List<MeetingListPlanListResponse> planList;
+
+    public MeetingListResponseV2(String email, Long meetingId, String meetingName, String description, String meetingImagePath, Long memberCount, String category) {
+
+        this.email = email;
+        this.meetingId = meetingId;
+        this.meetingName = meetingName;
+        this.description = description;
+        this.meetingImagePath = meetingImagePath;
+        this.memberCount = memberCount;
+        this.category = category;
+    }
+
+    public void setPlanList(List<MeetingListPlanListResponse> planListResponses) {
+
+        this.planList = planListResponses;
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDsl.java
@@ -18,4 +18,6 @@ public interface MeetingQueryDsl {
 
     MeetingCursorPagingResponse getMeetingList(Long cursor, int size, Long categoryId, String sort);
 
+    MeetingCursorPagingResponse getMeetingListV2(Long cursor, int size, Long categoryId, String sort);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -9,10 +9,7 @@ import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
-import com.wemo.backend.domain.meeting.dto.MeetingCursorPagingResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingListResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingPlanListResponse;
-import com.wemo.backend.domain.meeting.dto.MeetingReviewListResponse;
+import com.wemo.backend.domain.meeting.dto.*;
 import com.wemo.backend.domain.meeting.entity.Meeting;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import jakarta.persistence.EntityManager;
@@ -20,8 +17,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
@@ -219,6 +216,109 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                 .limit(size)
                 .fetch();  // .stream().toList()를 .fetch()로 수정
 
+        long meetingCount = Optional.ofNullable(
+                queryFactory
+                        .select(meeting.count())
+                        .from(meeting)
+                        .where(buildFilterConditions(categoryId))
+                        .where(meeting.deletedAt.isNull())
+                        .fetchOne()
+        ).orElse(0L);
+
+        return new MeetingCursorPagingResponse(meetingListResponses, (int) meetingCount);
+    }
+
+    @Override
+    public MeetingCursorPagingResponse getMeetingListV2(Long cursor, int size, Long categoryId, String sort) {
+
+        BooleanBuilder listConditions = new BooleanBuilder();
+        if (cursor != null) {
+            listConditions.and(meeting.id.lt(cursor));
+        }
+
+        // 1️⃣ Meeting 리스트 조회 (planList 제외)
+        List<MeetingListResponseV2> meetingListResponses = queryFactory
+                .select(Projections.constructor(
+                        MeetingListResponseV2.class,
+                        user.email,
+                        meeting.id,
+                        meeting.meetingName,
+                        meeting.description,
+                        Expressions.as(
+                                queryFactory.select(image.fileUrl)
+                                        .from(image)
+                                        .where(image.entityId.eq(meeting.id),
+                                                image.entityType.eq(Image.EntityType.MEETING),
+                                                image.main.eq(true)),
+                                "meetingImagePath"
+                        ),
+                        Expressions.as(
+                                JPAExpressions.select(meetingMember.count())
+                                        .from(meetingMember)
+                                        .where(meetingMember.meeting.id.eq(meeting.id)
+                                                .and(meetingMember.deletedAt.isNull())),
+                                "memberCount"
+                        ),
+                        meeting.category.categoryName
+                ))
+                .from(meeting)
+                .leftJoin(meeting.user, user)
+                .where(listConditions)
+                .where(buildFilterConditions(categoryId))
+                .where(meeting.deletedAt.isNull())
+                .orderBy(
+                        getOrderSpecifier(sort), // memberCount 정렬 기준
+                        meeting.createdAt.desc()  // createdAt 정렬 기준
+                )
+                .limit(size)
+                .fetch();
+
+        // 2️⃣ 각 Meeting ID에 대해 최근 3개의 Plan 리스트 조회
+        List<Long> meetingIds = meetingListResponses.stream()
+                .map(MeetingListResponseV2::getMeetingId)
+                .toList();
+
+        Map<Long, List<MeetingListPlanListResponse>> planMap = queryFactory
+                .select(Projections.constructor(
+                        MeetingListPlanListResponse.class,
+                        plan.id,
+                        plan.meeting.id,
+                        plan.planName,
+                        plan.dateTime,
+                        Expressions.as(
+                                queryFactory.select(attendance.count())
+                                        .from(attendance)
+                                        .where(attendance.plan.id.eq(plan.id)
+                                                .and(attendance.deletedAt.isNull())),
+                                "participants"
+                        ),
+                        plan.capacity,
+                        Expressions.as(
+                                queryFactory.select(image.fileUrl)
+                                        .from(image)
+                                        .where(image.entityId.eq(plan.id),
+                                                image.entityType.eq(Image.EntityType.PLAN),
+                                                image.main.eq(true)),
+                                "planImagePath"
+                        ),
+                        plan.opened,
+                        plan.fulled
+                ))
+                .from(plan)
+                .where(plan.meeting.id.in(meetingIds))
+                .orderBy(plan.dateTime.desc()) // 최신 일정 순으로 정렬
+                .fetch()
+                .stream()
+                .collect(Collectors.groupingBy(
+                        MeetingListPlanListResponse::getMeetingId,
+                        LinkedHashMap::new,
+                        Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().limit(3).toList())
+                ));
+        // 3️⃣ meetingListResponses에 planList 추가
+        for (MeetingListResponseV2 response : meetingListResponses) {
+            response.setPlanList(planMap.getOrDefault(response.getMeetingId(), new ArrayList<>()));
+        }
+        
         long meetingCount = Optional.ofNullable(
                 queryFactory
                         .select(meeting.count())

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingService.java
@@ -28,4 +28,6 @@ public interface MeetingService {
 
     String joinCancelMeeting(String email, Long meetingId);
 
+    MeetingCursorPagingResponse getMeetingListV2(Long cursor, int size, Long categoryId, String sort);
+
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -247,6 +247,23 @@ public class MeetingServiceImpl implements MeetingService {
         return "모임 가입 취소 완료";
     }
 
+    /**
+     * 모임 목록 조회 v2
+     * - 커서 기반 페이징 처리된 모임 목록 반환 (모임의 최근 일정 3개도 함께 반환)
+     *
+     * @param cursor     커서 id
+     * @param size       데이터 개수
+     * @param categoryId 카테고리 id
+     * @param sort       정렬 기준
+     * @return 요청 조건에 알맞은 모임 목록
+     */
+    @Override
+    public MeetingCursorPagingResponse getMeetingListV2(Long cursor, int size, Long categoryId, String sort) {
+
+        return meetingRepository.getMeetingListV2(cursor, size, categoryId, sort);
+
+    }
+
     // 유틸리티 메서드들
 
     /**

--- a/src/main/java/com/wemo/backend/domain/oauth/controller/Oauth2Controller.java
+++ b/src/main/java/com/wemo/backend/domain/oauth/controller/Oauth2Controller.java
@@ -28,7 +28,7 @@ public class Oauth2Controller {
         // 카카오 accessToken 요청
         String kakaoAccessToken = oauth2Service.getKakaoAccessToken(code);
         // 로그인 처리 및 응답 반환
-        return oauth2Service.kakaoLogin(kakaoAccessToken, response);
+        return oauth2Service.kakaoLogin(kakaoAccessToken, request, response);
     }
 
     @GetMapping("/google")
@@ -38,7 +38,7 @@ public class Oauth2Controller {
         // 구글 accessToken 요청
         String googleAccessToken = oauth2Service.getGoogleAccessToken(code);
         // 로그인 처리 및 응답 반환
-        return oauth2Service.googleLogin(googleAccessToken, response);
+        return oauth2Service.googleLogin(googleAccessToken, request, response);
     }
 
     @GetMapping("/naver")
@@ -48,7 +48,7 @@ public class Oauth2Controller {
         // 네이버 accessToken 요청
         String naverAccessToken = oauth2Service.getNaverAccessToken(code);
         // 로그인 처리 및 응답 반환
-        return oauth2Service.naverLogin(naverAccessToken, response);
+        return oauth2Service.naverLogin(naverAccessToken, request, response);
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2Service.java
+++ b/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2Service.java
@@ -1,6 +1,7 @@
 package com.wemo.backend.domain.oauth.service;
 
 import com.wemo.backend.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
@@ -10,14 +11,14 @@ public interface Oauth2Service {
 
     String getKakaoAccessToken(String code);
 
-    ResponseEntity<SuccessResponse<Void>> kakaoLogin(String kakaoAccessToken, HttpServletResponse response);
+    ResponseEntity<SuccessResponse<Void>> kakaoLogin(String kakaoAccessToken, HttpServletRequest request, HttpServletResponse response);
 
     String getGoogleAccessToken(String code);
 
-    ResponseEntity<SuccessResponse<Void>> googleLogin(String googleAccessToken, HttpServletResponse response);
+    ResponseEntity<SuccessResponse<Void>> googleLogin(String googleAccessToken, HttpServletRequest request, HttpServletResponse response);
 
     String getNaverAccessToken(String code);
 
-    ResponseEntity<SuccessResponse<Void>> naverLogin(String naverAccessToken, HttpServletResponse response);
+    ResponseEntity<SuccessResponse<Void>> naverLogin(String naverAccessToken, HttpServletRequest request, HttpServletResponse response);
 
 }

--- a/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
@@ -11,6 +11,7 @@ import com.wemo.backend.domain.user.service.UserStore;
 import com.wemo.backend.global.exception.CustomException;
 import com.wemo.backend.global.exception.ErrorCode;
 import com.wemo.backend.global.response.SuccessResponse;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,9 +65,9 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     }
 
     @Override
-    public ResponseEntity<SuccessResponse<Void>> kakaoLogin(String kakaoAccessToken, HttpServletResponse response) {
+    public ResponseEntity<SuccessResponse<Void>> kakaoLogin(String kakaoAccessToken, HttpServletRequest request, HttpServletResponse response) {
 
-        return processLogin(kakaoAccessToken, "https://kapi.kakao.com/v2/user/me", LoginType.KAKAO, response);
+        return processLogin(kakaoAccessToken, "https://kapi.kakao.com/v2/user/me", LoginType.KAKAO, request, response);
     }
 
     @Override
@@ -76,9 +77,9 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     }
 
     @Override
-    public ResponseEntity<SuccessResponse<Void>> googleLogin(String googleAccessToken, HttpServletResponse response) {
+    public ResponseEntity<SuccessResponse<Void>> googleLogin(String googleAccessToken, HttpServletRequest request, HttpServletResponse response) {
 
-        return processLogin(googleAccessToken, "https://www.googleapis.com/oauth2/v2/userinfo", LoginType.GOOGLE, response);
+        return processLogin(googleAccessToken, "https://www.googleapis.com/oauth2/v2/userinfo", LoginType.GOOGLE, request, response);
     }
 
     @Override
@@ -88,9 +89,9 @@ public class Oauth2ServiceImpl implements Oauth2Service {
     }
 
     @Override
-    public ResponseEntity<SuccessResponse<Void>> naverLogin(String naverAccessToken, HttpServletResponse response) {
+    public ResponseEntity<SuccessResponse<Void>> naverLogin(String naverAccessToken, HttpServletRequest request, HttpServletResponse response) {
 
-        return processLogin(naverAccessToken, "https://openapi.naver.com/v1/nid/me", LoginType.NAVER, response);
+        return processLogin(naverAccessToken, "https://openapi.naver.com/v1/nid/me", LoginType.NAVER, request, response);
     }
 
     private String getAccessToken(String tokenUrl, String code, String clientId, String clientSecret, String redirectUri) {
@@ -110,7 +111,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
         return response.get("access_token").asText();
     }
 
-    private ResponseEntity<SuccessResponse<Void>> processLogin(String accessToken, String userInfoUrl, LoginType loginType, HttpServletResponse response) {
+    private ResponseEntity<SuccessResponse<Void>> processLogin(String accessToken, String userInfoUrl, LoginType loginType, HttpServletRequest request, HttpServletResponse response) {
 
         log.info("processLogin() 메서드 호출");
 
@@ -132,7 +133,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
 
         // 쿠키에 refreshToken, accessToken 추가
         refreshTokenManager.setRefreshTokenInCookie(jwtRefreshToken, response);
-        accessTokenManager.setAccessTokenInCookie(jwtAccessToken, response);
+        accessTokenManager.setAccessTokenInCookie(jwtAccessToken, request, response);
 
         return buildResponseEntity();
     }

--- a/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/wemo/backend/domain/user/controller/UserController.java
@@ -60,9 +60,9 @@ public class UserController {
                     content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "/signin", method = RequestMethod.POST)
-    public ResponseEntity<SuccessResponse<String>> signin(@Valid @RequestBody SigninRequest request, HttpServletResponse response) {
+    public ResponseEntity<SuccessResponse<String>> signin(@Valid @RequestBody SigninRequest signinRequest, HttpServletRequest request, HttpServletResponse response) {
 
-        userService.signin(request, response);
+        userService.signin(signinRequest, request, response);
         return ResponseEntity.ok(SuccessResponse.successWithNoData("로그인 성공"));
     }
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
 
     void signup(UserCreateRequest request);
 
-    void signin(SigninRequest request, HttpServletResponse response);
+    void signin(SigninRequest signinRequest, HttpServletRequest request, HttpServletResponse response);
 
     String signout(HttpServletRequest request, HttpServletResponse response);
 

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -90,13 +90,13 @@ public class UserServiceImpl implements UserService {
      * @param signinRequest 아이디, 비밀번호로 로그인
      */
     @Override
-    public void signin(SigninRequest signinRequest, HttpServletResponse response) {
+    public void signin(SigninRequest signinRequest, HttpServletRequest request, HttpServletResponse response) {
 
         // 유저 검증 및 객체 조회
         User user = userReader.getUser(signinRequest.getEmail(), signinRequest.getPassword());
         log.info("사용자 {} 로그인 성공", user.getEmail());
 
-        userAuth.generateHeaderTokens(user, response);
+        userAuth.generateHeaderTokens(user, request, response);
     }
 
     /**

--- a/src/test/java/com/wemo/backend/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/wemo/backend/domain/user/service/UserServiceImplTest.java
@@ -7,6 +7,7 @@ import com.wemo.backend.domain.user.entity.LoginType;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.repository.UserRepository;
 import com.wemo.backend.global.exception.CustomException;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.*;
@@ -36,6 +37,9 @@ class UserServiceImplTest {
 
     @Autowired
     private HttpServletResponse response;
+
+    @Autowired
+    private HttpServletRequest request;
 
     @BeforeEach
     @Transactional
@@ -85,7 +89,7 @@ class UserServiceImplTest {
             // then
             assertTrue(userRepository.findByEmail("newuser@example.com").isPresent());
         }
-        
+
         @Test
         @DisplayName("로그인 해피 케이스 테스트")
         void signin_Success() {
@@ -96,7 +100,7 @@ class UserServiceImplTest {
             SigninRequest signinRequest = new SigninRequest(email, password);
 
             // when
-            userService.signin(signinRequest, response);
+            userService.signin(signinRequest, request, response);
 
             // then
             assertTrue(refreshTokenManager.existsByEmail(email)); // ✅ refreshToken 저장 여부 확인


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 모임 목록 조회 시 해당 모임의 최근 일정 3개를 반환하도록 수정하였습니다.
- 추후 성능 테스트를 위해 기존 API와 엔드포인트를 다르게 설정하여 기능을 추가하였습니다.
- 쿠키 설정을 동적으로 관리할 수 있도록 도메인의 형태에 따라 보안 설정을 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/meeting-list-126` -> `dev`
- close #126 

<br/>

## 🔥 트러블 슈팅 (선택)
- 프론트엔드 환경에 맞춰 쿠키 설정을 동적으로 처리하도록 수정하여, 로컬 환경과 배포 환경에서의 테스트를 원활하게 진행할 수 있도록 개선
  - 프론트엔드 팀의 제안을 반영하여 구현하였습니다. 감사합니다!

<br/>

## ⚙️ 배포 후 확인 사항
- 배포 후 로컬 환경과 배포 환경에서 쿠키 설정이 정상적으로 동작하는지 확인 필요
- 성능 테스트 결과를 통해 추가적인 최적화가 필요한지 점검 예정
