### PR TITLE
[Refactor] 쿠키 삭제 로직 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/AccessTokenManager.java
@@ -49,7 +49,7 @@ public class AccessTokenManager {
     public void deleteAccessTokenInCookie(HttpServletResponse response) {
 
         // 쿠키 만료 시간 설정 (과거 날짜로 설정하여 Expires 명시적으로 제거)
-        String expiredDate = "Thu, 01 Jan 1970 00:00:00 GMT";
+//        String expiredDate = "Thu, 01 Jan 1970 00:00:00 GMT";
 
         ResponseCookie cookie = ResponseCookie.from("accessToken", null)
                 .maxAge(0)
@@ -60,7 +60,8 @@ public class AccessTokenManager {
                 .build();
 
         // 'Expires' 헤더를 과거 날짜로 설정하여 쿠키 만료 처리
-        response.addHeader(HttpHeaders.SET_COOKIE, cookie + "; Expires=" + expiredDate);
+//        response.addHeader(HttpHeaders.SET_COOKIE, cookie + "; Expires=" + expiredDate);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         log.info("accessToken 쿠키 삭제 완료");
 


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- accessToken 쿠키 관련 로직 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- `feat/lightning-create-133` -> `dev`
- close #133 

<br/>

## 🔥 트러블 슈팅 (선택)
- 쿠키의 maxAge를 0으로 설정하였으나 프론트 브라우저에서 자동으로 삭제되지 않는 오류 발생
  -> accessToken 쿠키 생성 시 도메인 설정을 `.we-mo.shop`으로 수정하였던 부분에 의해 도메인이 일치하지 않아서 쿠키의 설정이 적용되지 않았음
   -> 쿠키 생성 시 도메인 설정을 수정하여 쿠키가 브라우저 내에서 자동으로 삭제되도록 해결