### PR TITLE
[Feat] 번개 모임 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -125,7 +125,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         return EXCLUDED_PATHS.stream().anyMatch(requestURI::startsWith)
                 || (requestURI.startsWith("/api/meetings") && "GET".equalsIgnoreCase(method) && accessToken == null)
                 || (requestURI.startsWith("/api/plans") && "GET".equalsIgnoreCase(method) && !requestURI.contains("like") && accessToken == null)
-                || (requestURI.startsWith("/api/reviews") && "GET".equalsIgnoreCase(method));
+                || (requestURI.startsWith("/api/reviews") && "GET".equalsIgnoreCase(method))
+                || ("/api/lightnings".equals(requestURI) && "GET".equalsIgnoreCase(method))
+                || (requestURI.startsWith("/api/lightnings?") && "GET".equalsIgnoreCase(method));
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message, HttpStatus httpStatus) throws IOException {

--- a/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
@@ -3,21 +3,21 @@ package com.wemo.backend.domain.lightning.controller;
 import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
+import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import com.wemo.backend.domain.lightning.service.LightningService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Lightnings")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/lightnings")
@@ -36,6 +36,23 @@ public class LightningController {
                                                                                      @Valid @RequestBody LightningCreateRequest request) {
 
         return ResponseEntity.status(201).body(SuccessResponse.successWithData(lightningService.createLightnings(userDetails.getUsername(), request)));
+    }
+
+    @Operation(summary = "번개 모임 목록 조회", description = "번개 모임 일정의 목록을 반환합니다.")
+    @ApiResponse(responseCode = "200", description = "요청한 일정 목록이 반환되었습니다.")
+    @RequestMapping(value = "", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<LightningCursorPagingResponse>> getLightningMeetingList(@RequestParam(required = false) Long cursor,
+                                                                                                  @RequestParam(required = false, defaultValue = "10") int size,
+                                                                                                  @RequestParam(required = false) String province,
+                                                                                                  @RequestParam(required = false) String district,
+                                                                                                  @RequestParam(required = false) Long lightningTypeId,
+                                                                                                  @RequestParam(required = false) Integer lightningTimeId,
+                                                                                                  @RequestParam(required = false) Double latitude,
+                                                                                                  @RequestParam(required = false) Double longitude,
+                                                                                                  @RequestParam(required = false, defaultValue = "1.0") Double radius) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.getLightningMeetingList(cursor, size, province, district,
+                lightningTypeId, lightningTimeId, latitude, longitude, radius)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningCursorPagingResponse.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningCursorPagingResponse.java
@@ -1,0 +1,25 @@
+package com.wemo.backend.domain.lightning.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class LightningCursorPagingResponse {
+
+    private int lightningCount;
+
+    private List<LightningListResponse> lightningList;
+
+    private Long nextCursor;
+
+    public LightningCursorPagingResponse(List<LightningListResponse> lightningList, int lightningCount) {
+
+        this.lightningCount = lightningCount;
+        this.lightningList = lightningList;
+        this.nextCursor = lightningList.isEmpty() ? null : lightningList.get(lightningList.size() - 1).getLightningId();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningListResponse.java
@@ -1,0 +1,46 @@
+package com.wemo.backend.domain.lightning.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class LightningListResponse {
+
+    private Long lightningId;
+
+    private String lightningName;
+
+    private String lightningType;
+
+    private String lightningTime;
+
+    private LocalDateTime lightningDate;
+
+    private int lightningCapacity;
+
+    private Long lightningParticipants;
+
+    private String address;
+
+    private double latitude;
+
+    private double longitude;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    public void setLightningTime(String displayName) {
+
+        this.lightningTime = displayName;
+
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightning/entity/DateType.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/entity/DateType.java
@@ -24,4 +24,9 @@ public enum DateType {
                 .findFirst()
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 번개 모임 시간 타입입니다."));
     }
+    
+    public String getDisplayName() {
+
+        return this.name;
+    }
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/entity/Lightning.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/entity/Lightning.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.lightning.entity;
 
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.entity.Timestamped;
 import jakarta.persistence.*;
@@ -59,6 +60,11 @@ public class Lightning extends Timestamped {
     @Column(name = "address", nullable = false)
     @Comment("모임 장소")
     private String address;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "district_id", nullable = false)
+    @Comment("군/구 id")
+    private District district;
 
     @Column(name = "latitude", nullable = false)
     @Comment("위도")

--- a/src/main/java/com/wemo/backend/domain/lightning/repository/LightningRepository.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/repository/LightningRepository.java
@@ -1,7 +1,9 @@
 package com.wemo.backend.domain.lightning.repository;
 
 import com.wemo.backend.domain.lightning.entity.Lightning;
+import com.wemo.backend.domain.lightning.repository.querydsl.LightningCursorQueryDsl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface LightningRepository extends JpaRepository<Lightning, Long> {
+public interface LightningRepository extends JpaRepository<Lightning, Long>, LightningCursorQueryDsl {
+
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDsl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDsl.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.lightning.repository.querydsl;
+
+import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
+
+public interface LightningCursorQueryDsl {
+
+    LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius);
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
@@ -1,0 +1,137 @@
+package com.wemo.backend.domain.lightning.repository.querydsl;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
+import com.wemo.backend.domain.lightning.dto.LightningListResponse;
+import com.wemo.backend.domain.lightning.entity.DateType;
+import com.wemo.backend.domain.region.entity.QDistrict;
+import jakarta.persistence.EntityManager;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+import static com.wemo.backend.domain.lightning.entity.QLightning.lightning;
+import static com.wemo.backend.domain.lightningJoin.entity.QLightningJoin.lightningJoin;
+import static com.wemo.backend.domain.user.entity.QUser.user;
+
+@Slf4j
+public class LightningCursorQueryDslImpl implements LightningCursorQueryDsl {
+
+    private final JPAQueryFactory queryFactory;
+
+    public LightningCursorQueryDslImpl(EntityManager em) {
+
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius) {
+
+        log.info("번개 모임 목록 조회 요청");
+
+        // 커서 조건을 제외한 기본 조건 빌더
+        BooleanBuilder baseConditions = new BooleanBuilder()
+                .and(buildFilterConditions(province, district, lightningTypeId, lightningTimeId, latitude, longitude, radius));
+
+        // 목록 조회 쿼리 (커서 조건 포함)
+        BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
+        if (cursor != null) {
+            listConditions.and(lightning.id.lt(cursor));
+        }
+
+        List<LightningListResponse> lightningListResponses = queryFactory
+                .select(
+                        Projections.constructor(
+                                LightningListResponse.class,
+                                lightning.id,
+                                lightning.lightningName,
+                                lightning.lightningType.lightTypeName,
+                                lightning.dateType.stringValue(),
+                                lightning.lightningDate,
+                                lightning.lightningCapacity,
+                                Expressions.as(
+                                        JPAExpressions.select(lightningJoin.count())
+                                                .from(lightningJoin)
+                                                .where(lightningJoin.lightning.id.eq(lightning.id)),
+                                        "lightningParticipants"
+                                ),
+                                lightning.address,
+                                lightning.latitude,
+                                lightning.longitude,
+                                lightning.createdAt,
+                                lightning.updatedAt,
+                                user.nickname,
+                                user.profileImagePath
+                        )
+                )
+                .from(lightning)
+                .leftJoin(lightning.user, user)
+                .where(listConditions)
+                .limit(size)
+                .orderBy(lightning.createdAt.desc())
+                .fetch();
+
+        // 쿼리 결과 후, lightningTime 값에 대해 getDisplayName()을 호출하여 변환
+        lightningListResponses.forEach(response -> {
+            response.setLightningTime(DateType.valueOf(response.getLightningTime()).getDisplayName());  // 변환된 값으로 설정
+        });
+
+        return new LightningCursorPagingResponse(lightningListResponses, lightningListResponses.size());
+    }
+
+    private BooleanExpression buildFilterConditions(String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius) {
+
+        BooleanExpression condition = lightning.deletedAt.isNull(); // 기본 필터 조건
+
+        condition = buildRegionFilter(province, district, condition, lightning.district);
+
+        if (lightningTypeId != null) {
+            condition = condition.and(lightning.lightningType.lightningTypeId.eq(lightningTypeId));
+        }
+
+        if (lightningTimeId != null && (lightningTimeId == 1 || lightningTimeId == 2 || lightningTimeId == 3)) {
+
+            DateType dateType = DateType.fromId(lightningTimeId);
+            condition = condition.and(lightning.dateType.eq(dateType));
+        }
+
+        return buildAddressFilter(province, district, latitude, longitude, radius, condition);
+    }
+
+    public static BooleanExpression buildRegionFilter(String province, String district, BooleanExpression condition, QDistrict district2) {
+
+        if (province != null && !province.isEmpty()) {
+            condition = condition.and(district2.province.provinceName.eq(province));
+        }
+
+        if (district != null && !district.isEmpty()) {
+            condition = condition.and(district2.districtName.eq(district));
+        }
+        return condition;
+    }
+
+
+    public static BooleanExpression buildAddressFilter(String province, String district, Double latitude, Double longitude, Double radius, BooleanExpression condition) {
+
+        if ((province == null || province.isEmpty()) && (district == null || district.isEmpty())) {
+            if (latitude != null && longitude != null && radius != null) {
+                double radiusInMeters = radius * 1000; // km → m 변환
+
+                NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
+                        "ST_Distance_Sphere(point({0}, {1}), point(plan.longitude, plan.latitude))",
+                        longitude, latitude);
+
+                condition = condition.and(distance.loe(radiusInMeters));
+            }
+        }
+
+        return condition;
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
@@ -79,7 +79,7 @@ public class LightningCursorQueryDslImpl implements LightningCursorQueryDsl {
 
         // 쿼리 결과 후, lightningTime 값에 대해 getDisplayName()을 호출하여 변환
         lightningListResponses.forEach(response -> {
-            response.setLightningTime(DateType.valueOf(response.getLightningTime()).getDisplayName());  // 변환된 값으로 설정
+            response.setLightningTime(Enum.valueOf(DateType.class, response.getLightningTime()).getDisplayName());  // 변환된 값으로 설정
         });
 
         return new LightningCursorPagingResponse(lightningListResponses, lightningListResponses.size());

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
@@ -2,11 +2,14 @@ package com.wemo.backend.domain.lightning.service;
 
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
+import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface LightningService {
 
     LightningCreateResponse createLightnings(String email, LightningCreateRequest request);
+
+    LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
@@ -2,14 +2,23 @@ package com.wemo.backend.domain.lightning.service;
 
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
+import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
+import com.wemo.backend.domain.lightning.repository.LightningRepository;
 import com.wemo.backend.domain.lightningJoin.service.LightningJoinStore;
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.region.entity.Province;
+import com.wemo.backend.domain.region.repository.DistrictRepository;
+import com.wemo.backend.domain.region.repository.ProvinceRepository;
+import com.wemo.backend.domain.region.service.RegionServiceImpl;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -19,9 +28,15 @@ public class LightningServiceImpl implements LightningService {
 
     private final LightningTypeReader lightningTypeReader;
 
+    private final ProvinceRepository provinceRepository;
+
+    private final DistrictRepository districtRepository;
+
     private final LightningStore lightningStore;
 
     private final LightningJoinStore lightningJoinStore;
+
+    private final LightningRepository lightningRepository;
 
     /**
      * 번개 모임 생성
@@ -36,12 +51,50 @@ public class LightningServiceImpl implements LightningService {
 
         User user = userReader.getUserByEmail(email);
         LightningType lightningType = lightningTypeReader.getLightningType(request.getLightningTypeId());
-        Lightning lightning = lightningStore.store(user, lightningType, request);
+
+        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(request.getAddress());
+        Province province = getOrSaveProvince(parsedAddress.get("province"));
+        District district = getOrSaveDistrict(parsedAddress.get("district"), province);
+
+        Lightning lightning = lightningStore.store(user, lightningType, district, request);
 
         // 주최자는 자동 참여
         lightningJoinStore.store(user, lightning);
 
         return LightningCreateResponse.fromEntity(lightning);
     }
+
+    /**
+     * 번개모임 목록 조회
+     *
+     * @param cursor          커서 id
+     * @param size            조회 요청 개수
+     * @param province        시/도
+     * @param district        군/구
+     * @param lightningTypeId 번개 모임 종류 id
+     * @param lightningTimeId 번개 모임 시간 타입 id
+     * @param latitude        위도
+     * @param longitude       경도
+     * @param radius          반경
+     * @return 조건에 맞는 데이터 목록
+     */
+    @Override
+    public LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius) {
+
+        return lightningRepository.getLightningMeetingList(cursor, size, province, district, lightningTypeId, lightningTimeId, latitude, longitude, radius);
+    }
+
+    private Province getOrSaveProvince(String provinceName) {
+
+        return provinceRepository.findByProvinceName(provinceName)
+                .orElseGet(() -> provinceRepository.save(new Province(provinceName)));
+    }
+
+    private District getOrSaveDistrict(String districtName, Province province) {
+
+        return districtRepository.findByDistrictNameAndProvince(districtName, province)
+                .orElseGet(() -> districtRepository.save(new District(districtName, province)));
+    }
+
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
@@ -3,10 +3,11 @@ package com.wemo.backend.domain.lightning.service;
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.user.entity.User;
 
 public interface LightningStore {
 
-    Lightning store(User user, LightningType lightningType, LightningCreateRequest request);
+    Lightning store(User user, LightningType lightningType, District district, LightningCreateRequest request);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
@@ -5,6 +5,7 @@ import com.wemo.backend.domain.lightning.entity.DateType;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
 import com.wemo.backend.domain.lightning.repository.LightningRepository;
+import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.user.entity.User;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -18,7 +19,7 @@ public class LightningStoreImpl implements LightningStore {
 
     @Override
     @Transactional
-    public Lightning store(User user, LightningType lightningType, LightningCreateRequest request) {
+    public Lightning store(User user, LightningType lightningType, District district, LightningCreateRequest request) {
 
         Lightning lightning = Lightning.builder()
                 .user(user)
@@ -29,6 +30,7 @@ public class LightningStoreImpl implements LightningStore {
                 .lightningContent(request.getLightningContent())
                 .lightningCapacity(request.getLightningCapacity())
                 .address(request.getAddress())
+                .district(district)
                 .latitude(request.getLatitude())
                 .longitude(request.getLongitude())
                 .build();

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/controller/LightningJoinController.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/controller/LightningJoinController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "Lightnings")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/lightnings/participation")

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/repository/LightningJoinRepository.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/repository/LightningJoinRepository.java
@@ -9,4 +9,6 @@ public interface LightningJoinRepository extends JpaRepository<LightningJoin, Lo
 
     boolean existsByUserAndLightning(User user, Lightning lightning);
 
+    long countByLightning(Lightning lightning);
+
 }

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinReader.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinReader.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.lightningJoin.service;
+
+import com.wemo.backend.domain.lightning.entity.Lightning;
+
+public interface LightningJoinReader {
+
+    int getParticipantsCount(Lightning lightning);
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinReaderImpl.java
@@ -1,0 +1,20 @@
+package com.wemo.backend.domain.lightningJoin.service;
+
+import com.wemo.backend.domain.lightning.entity.Lightning;
+import com.wemo.backend.domain.lightningJoin.repository.LightningJoinRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class LightningJoinReaderImpl implements LightningJoinReader {
+
+    private final LightningJoinRepository lightningJoinRepository;
+
+    @Override
+    public int getParticipantsCount(Lightning lightning) {
+
+        return (int) lightningJoinRepository.countByLightning(lightning);
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinServiceImpl.java
@@ -4,10 +4,13 @@ import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.service.LightningReader;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
+import com.wemo.backend.global.exception.CustomException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import static com.wemo.backend.global.exception.ErrorCode.LIGHTNING_MEETING_IS_FULL;
 
 @Slf4j
 @Service
@@ -19,6 +22,8 @@ public class LightningJoinServiceImpl implements LightningJoinService {
     private final LightningReader lightningReader;
 
     private final LightningJoinStore lightningJoinStore;
+
+    private final LightningJoinReader lightningJoinReader;
 
     /**
      * 번개 모임 참여
@@ -33,6 +38,10 @@ public class LightningJoinServiceImpl implements LightningJoinService {
 
         User user = userReader.getUserByEmail(email);
         Lightning lightning = lightningReader.getLightningById(lightningId);
+
+        int currentParticipants = lightningJoinReader.getParticipantsCount(lightning);
+        if (currentParticipants >= lightning.getLightningCapacity())
+            throw new CustomException(LIGHTNING_MEETING_IS_FULL);
 
         lightningJoinStore.store(user, lightning);
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -5,9 +5,9 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
+import com.wemo.backend.domain.lightning.repository.querydsl.LightningCursorQueryDslImpl;
 import com.wemo.backend.domain.plan.dto.PlanCursorPagingResponse;
 import com.wemo.backend.domain.plan.dto.PlanListResponse;
 import com.wemo.backend.domain.plan.entity.Plan;
@@ -21,6 +21,7 @@ import java.util.Optional;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
+import static com.wemo.backend.domain.lightning.repository.querydsl.LightningCursorQueryDslImpl.buildAddressFilter;
 import static com.wemo.backend.domain.like.entity.QLikes.likes;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
@@ -64,7 +65,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
         BooleanBuilder baseConditions = new BooleanBuilder()
                 .and(buildFilterConditions(query, province, district, startDate, endDate, categoryId, latitude, longitude, radius));
 
-        // 1. 목록 조회 쿼리 (커서 조건 포함)
+        // 목록 조회 쿼리 (커서 조건 포함)
         BooleanBuilder listConditions = new BooleanBuilder(baseConditions);
         if (cursor != null) {
             Plan targetPlan = queryFactory
@@ -89,7 +90,6 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
             }
         }
 
-
         List<PlanListResponse> planListResponses = queryFactory
                 .select(buildPlanListProjection(email))
                 .from(plan)
@@ -105,7 +105,7 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                 .limit(size)
                 .fetch();
 
-        // 2. 전체 개수 조회 쿼리 (커서 조건 제외)
+        // 전체 개수 조회 쿼리 (커서 조건 제외)
         long planCount = Optional.ofNullable(
                 queryFactory
                         .select(plan.count())
@@ -207,19 +207,21 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                                                     String startDate, String endDate, Long categoryId,
                                                     Double latitude, Double longitude, Double radius) {
 
+        BooleanExpression booleanExpression = buildFilterForPlanList(query, province, district, startDate, endDate, categoryId);
+
+        // 위치 기반 필터링 추가 (필터가 없는 경우)
+        return buildAddressFilter(province, district, latitude, longitude, radius, booleanExpression);
+    }
+
+    static BooleanExpression buildFilterForPlanList(String query, String province, String district, String startDate, String endDate, Long categoryId) {
+
         BooleanExpression condition = plan.canceled.eq(false);
 
         if (query != null && !query.isEmpty()) {
             condition = condition.and(plan.planName.contains(query));
         }
 
-        if (province != null && !province.isEmpty()) {
-            condition = condition.and(plan.district.province.provinceName.eq(province));
-        }
-
-        if (district != null && !district.isEmpty()) {
-            condition = condition.and(plan.district.districtName.eq(district));
-        }
+        condition = LightningCursorQueryDslImpl.buildRegionFilter(province, district, condition, plan.district);
 
         condition = UserQueryDslImpl.buildDateFilter(startDate, endDate, condition);
 
@@ -228,19 +230,6 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
                 condition = condition.and(plan.meeting.category.parentId.eq(categoryId));
             } else {
                 condition = condition.and(plan.meeting.category.id.eq(categoryId));
-            }
-        }
-
-        // 위치 기반 필터링 추가 (필터가 없는 경우)
-        if ((province == null || province.isEmpty()) && (district == null || district.isEmpty())) {
-            if (latitude != null && longitude != null && radius != null) {
-                double radiusInMeters = radius * 1000; // km → m 변환
-
-                NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
-                        "ST_Distance_Sphere(point({0}, {1}), point(plan.longitude, plan.latitude))",
-                        longitude, latitude);
-
-                condition = condition.and(distance.loe(radiusInMeters));
             }
         }
 

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanQueryDslImpl.java
@@ -10,7 +10,6 @@ import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.plan.dto.PlanListResponse;
 import com.wemo.backend.domain.region.entity.QDistrict;
 import com.wemo.backend.domain.region.entity.QProvince;
-import com.wemo.backend.domain.user.repository.querydsl.UserQueryDslImpl;
 import jakarta.persistence.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -177,31 +176,8 @@ public class PlanQueryDslImpl implements PlanQueryDsl {
 
     private BooleanExpression buildFilterConditions(String query, String province, String district, String startDate, String endDate, Long categoryId) {
 
-        BooleanExpression condition = plan.canceled.eq(false);
+        return PlanCursorQueryDslImpl.buildFilterForPlanList(query, province, district, startDate, endDate, categoryId);
 
-        if (query != null && !query.isEmpty()) {
-            condition = condition.and(plan.planName.contains(query));
-        }
-
-        if (province != null && !province.isEmpty()) {
-            condition = condition.and(plan.district.province.provinceName.eq(province));
-        }
-
-        if (district != null && !district.isEmpty()) {
-            condition = condition.and(plan.district.districtName.eq(district));
-        }
-
-        condition = UserQueryDslImpl.buildDateFilter(startDate, endDate, condition);
-
-        if (categoryId != null) {
-            if (categoryId == 1) {
-                condition = condition.and(plan.meeting.category.parentId.eq(categoryId)); // parentId가 1인 경우
-            } else {
-                condition = condition.and(plan.meeting.category.id.eq(categoryId)); // categoryId가 1이 아닌 경우는 해당 id 필터링
-            }
-        }
-
-        return condition;
     }
 
 }

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -103,6 +103,7 @@ public class SecurityConfig {
                         .requestMatchers(GET, "/api/plans/**").permitAll()
                         .requestMatchers(GET, "/api/reviews/**").permitAll()
                         .requestMatchers(GET, "/api/regions/**").permitAll()
+                        .requestMatchers(GET, "/api/lightnings/**").permitAll()
 
                         .anyRequest().authenticated()
 

--- a/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SwaggerConfig.java
@@ -20,6 +20,7 @@ public class SwaggerConfig {
                 .addTagsItem(new Tag().name("Images").description("이미지 관련 API"))
                 .addTagsItem(new Tag().name("Meetings").description("모임 관련 API"))
                 .addTagsItem(new Tag().name("Plans").description("일정 관련 API"))
+                .addTagsItem(new Tag().name("Lightnings").description("번개 모임 관련 API"))
                 .addTagsItem(new Tag().name("Reviews").description("후기 관련 API"))
                 .addTagsItem(new Tag().name("Regions").description("지역 관련 API"))
                 .addTagsItem(new Tag().name("Tokens").description("토큰 관련 API"))

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -57,7 +57,8 @@ public enum ErrorCode {
 
     // Lightning
     LIGHTNING_MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 번개 모임입니다."),
-    ALREADY_JOINED_LIGHTNING_MEETING(HttpStatus.BAD_REQUEST, "이미 참여된 모임입니다.");
+    ALREADY_JOINED_LIGHTNING_MEETING(HttpStatus.BAD_REQUEST, "이미 참여된 모임입니다."),
+    LIGHTNING_MEETING_IS_FULL(HttpStatus.BAD_REQUEST, "정원이 마감된 모임입니다.");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 📌 작업 내용 (필수)

### 🔄 변경된 내용
- **지역 데이터 추가 저장**: 번개 모임 데이터에 **지역 정보를 포함**하도록 수정하여, 지역별 필터링이 가능하도록 변경했습니다.
- **모임 참여 로직 개선**:  
  - 기존 참여 내역 검증 로직을 추가하여 **중복 참여를 방지**했습니다.  
  - **주최자는 모임 생성 시 자동으로 참여**하도록 수정했습니다.
- **공통 필터링 로직 분리**:  
  - 번개 모임 목록 조회 시 **다른 메서드에서도 재사용될 수 있도록 필터링 조건을 별도 메서드로 분리**했습니다.

### ✨ 추가된 기능
- **번개 모임 목록 조회 기능 구현**  
  - 지역, 모임 종류, 시간 종류별 필터링이 가능하며 요청 조건에 맞는 응답 목록을 반환합니다.

<br/>

## 🌱 반영 브랜치
- `feat/ligthning-list-141` -> `dev`
- close #141 

<br>

## 🔥 트러블 슈팅

### 🏷 ENUM 타입 한글 변환 문제  
#### 📌 문제 상황  
- 번개 모임의 **시간 종류 데이터**가 `ENUM`(`DateType`)으로 관리되고 있음
- 목록 조회 시 응답 데이터에서 **ENUM 값을 한글 형태(예: `출근 전`, `점심 시간`)로 변환하여 제공** 하고자 함
- 하지만 **QueryDSL에서는 ENUM 타입의 필드를 직접 변환하여 반환하는 기능이 없음**
- 따라서 조회된 데이터를 **수동으로 변환하는 추가 작업이 필요**했음

#### ✅ 해결 방법  
쿼리 결과를 받은 후, **forEach를 사용하여 ENUM 값을 한글 값으로 변환**함
```java
// 쿼리 결과 후, lightningTime 값에 대해 getDisplayName()을 호출하여 변환
lightningListResponses.forEach(response -> {
    response.setLightningTime(Enum.valueOf(DateType.class, response.getLightningTime()).getDisplayName()); 
});
```

- DateType.valueOf(response.getLightningTime()).getDisplayName()
  - response.getLightningTime() → ENUM 값(MORNING, LUNCH, EVENING)을 가져옴
  - DateType.valueOf() → 해당 ENUM 타입으로 변환
  - getDisplayName() → 한글 명칭(출근 전, 점심시간, 퇴근 후)으로 변환

#### 🔍 결론
✅ QueryDSL에서 ENUM 변환이 어렵기 때문에, 응답 데이터를 변환하는 방식으로 해결
✅ 유지보수성을 고려해 DB 쿼리에서 직접 변환하지 않고, 비즈니스 로직에서 처리하는 방식으로 적용
