### PR TITLE
[Feat] 번개 모임 상세 조회 기능 구현

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -7,9 +7,25 @@ on:
     branches: [ "dev" ]
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      # 다른 빌드 작업을 추가할 수 있습니다.
+
+  # 독립적인 작업 추가 (예: check)
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check the code status
+        run: echo "Code check complete."
+
   deploy:
     runs-on: ubuntu-latest
-    needs: build  # CI가 성공한 후 실행
+    needs: build  # build 작업이 완료된 후 실행
     permissions:
       contents: read
 
@@ -27,19 +43,16 @@ jobs:
           script: |
             echo "🔍 현재 활성화된 컨테이너 확인..."
             ACTIVE_CONTAINER=$(docker ps --format "{{.Names}}" | grep 'wemo-blue\|wemo-green')
-
             if [ "$ACTIVE_CONTAINER" == "wemo-blue" ]; then
                 IDLE_CONTAINER="wemo-green"
             else
                 IDLE_CONTAINER="wemo-blue"
             fi
-
             echo "🚀 새로운 버전 실행 중: $IDLE_CONTAINER"
             docker-compose -f /home/ubuntu/docker-compose.yml up -d --no-deps --build $IDLE_CONTAINER
             
             echo "⏳ 컨테이너 실행 확인..."
             sleep 10  # 컨테이너가 정상 실행될 때까지 대기
-
             echo "🔀 Nginx 트래픽 전환"
             if [ "$IDLE_CONTAINER" == "wemo-green" ]; then
                 sed -i 's/wemo-blue/wemo-green/g' /home/ubuntu/nginx/nginx.conf
@@ -47,7 +60,6 @@ jobs:
                 sed -i 's/wemo-green/wemo-blue/g' /home/ubuntu/nginx/nginx.conf
             fi
             docker exec wemo-nginx nginx -s reload  # Nginx 설정 리로드
-
             echo "🛑 기존 컨테이너 중지: $ACTIVE_CONTAINER"
             docker stop $ACTIVE_CONTAINER
             docker rm $ACTIVE_CONTAINER

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,31 +9,45 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    needs: build  # CI가 성공한 후 실행
     permissions:
       contents: read
 
     steps:
-      # 1. GitHub 저장소에서 코드 체크아웃
       - name: Checkout code
         uses: actions/checkout@v4
 
-      # 2. SSH 접속을 통해 EC2에서 Docker Compose로 배포
-      - name: EC2 접속 후 Docker Compose 로 배포
+      - name: EC2 접속 후 Blue-Green 배포 수행
         uses: appleboy/ssh-action@v0.1.5
         with:
-          host: ${{ secrets.SERVER_HOST }}  # EC2 서버 IP
-          username: ${{ secrets.SERVER_USER }}  # EC2 서버 로그인 사용자
-          key: ${{ secrets.SSH_PRIVATE_KEY }}  # EC2 SSH private key
-          port: 22  # EC2 SSH 포트
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          port: 22
           script: |
-            # 3. 기존 Docker Compose 중지 및 제거
-            echo "Stopping and removing existing containers..."
-            docker-compose -f /home/ubuntu/docker-compose.yml down
+            echo "🔍 현재 활성화된 컨테이너 확인..."
+            ACTIVE_CONTAINER=$(docker ps --format "{{.Names}}" | grep 'wemo-blue\|wemo-green')
+
+            if [ "$ACTIVE_CONTAINER" == "wemo-blue" ]; then
+                IDLE_CONTAINER="wemo-green"
+            else
+                IDLE_CONTAINER="wemo-blue"
+            fi
+
+            echo "🚀 새로운 버전 실행 중: $IDLE_CONTAINER"
+            docker-compose -f /home/ubuntu/docker-compose.yml up -d --no-deps --build $IDLE_CONTAINER
             
-            # 4. 최신 Docker 이미지 pull
-            echo "Pulling latest Docker images..."
-            docker-compose -f /home/ubuntu/docker-compose.yml pull
-            
-            # 5. Docker Compose로 애플리케이션 재시작
-            echo "Starting application with Docker Compose..."
-            docker-compose -f /home/ubuntu/docker-compose.yml up -d
+            echo "⏳ 컨테이너 실행 확인..."
+            sleep 10  # 컨테이너가 정상 실행될 때까지 대기
+
+            echo "🔀 Nginx 트래픽 전환"
+            if [ "$IDLE_CONTAINER" == "wemo-green" ]; then
+                sed -i 's/wemo-blue/wemo-green/g' /home/ubuntu/nginx/nginx.conf
+            else
+                sed -i 's/wemo-green/wemo-blue/g' /home/ubuntu/nginx/nginx.conf
+            fi
+            docker exec wemo-nginx nginx -s reload  # Nginx 설정 리로드
+
+            echo "🛑 기존 컨테이너 중지: $ACTIVE_CONTAINER"
+            docker stop $ACTIVE_CONTAINER
+            docker rm $ACTIVE_CONTAINER

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         run: docker push ${{ secrets.DOCKERHUB_USERNAME }}/wemo
 
       - name: Cleanup .env file
-        run: rm .env
+        run: rm -f .env
 
   dependency-submission:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,18 +5,10 @@ on:
     branches: [ "dev" ]
   pull_request:
     branches: [ "dev" ]
-    
+
 jobs:
   build:
     runs-on: ubuntu-latest
-    services:
-      wemo-testdb:
-        image: mysql:latest
-        env:
-          MYSQL_ROOT_PASSWORD: test
-          MYSQL_DATABASE: wemo-test
-        ports:
-          - 3313:3306
 
     steps:
       - uses: actions/checkout@v4
@@ -26,9 +18,6 @@ jobs:
         with:
           java-version: '17'
           distribution: 'temurin'
-
-      - name: 테스트용 .env 파일 생성
-        run: echo "${{ secrets.TEST_ENV }}" > .env
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -18,7 +18,9 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -27,7 +29,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtTokenProvider jwtTokenProvider;
 
     private final AccessTokenManager accessTokenManager;
-    
+
     private static final List<String> EXCLUDED_PATHS = List.of(
             "/api/auths/check-email", "/api/auths/signin", "/api/auths/signup", "/swagger-ui/", "/swagger-ui.html",
             "/v3/api-docs", "/api/regions", "/api/auths/reissue", "/login/oauth2/callback/kakao",
@@ -122,12 +124,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private boolean shouldSkipFilter(String requestURI, String method, String accessToken) {
 
-        return EXCLUDED_PATHS.stream().anyMatch(requestURI::startsWith)
-                || (requestURI.startsWith("/api/meetings") && "GET".equalsIgnoreCase(method) && accessToken == null)
-                || (requestURI.startsWith("/api/plans") && "GET".equalsIgnoreCase(method) && !requestURI.contains("like") && accessToken == null)
-                || (requestURI.startsWith("/api/reviews") && "GET".equalsIgnoreCase(method))
-                || ("/api/lightnings".equals(requestURI) && "GET".equalsIgnoreCase(method))
-                || (requestURI.startsWith("/api/lightnings?") && "GET".equalsIgnoreCase(method));
+        if (EXCLUDED_PATHS.stream().anyMatch(requestURI::startsWith)) {
+            return true;
+        }
+
+        boolean isGetMethod = "GET".equalsIgnoreCase(method);
+        if (!isGetMethod) return false;
+
+        Map<Predicate<String>, Predicate<String>> conditions = Map.of(
+                uri -> uri.equals("/api/lightnings") || uri.startsWith("/api/lightnings?"), req -> true,
+                uri -> uri.matches("^/api/lightnings/\\d+$"), req -> accessToken == null,
+                uri -> uri.startsWith("/api/meetings"), req -> accessToken == null,
+                uri -> uri.startsWith("/api/plans") && !uri.contains("like"), req -> accessToken == null,
+                uri -> uri.startsWith("/api/reviews"), req -> true
+        );
+
+        return conditions.entrySet().stream()
+                .filter(entry -> entry.getKey().test(requestURI))
+                .map(Map.Entry::getValue)
+                .anyMatch(condition -> condition.test(requestURI));
     }
 
     private void sendErrorResponse(HttpServletResponse response, String message, HttpStatus httpStatus) throws IOException {

--- a/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
@@ -4,6 +4,7 @@ import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
+import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
 import com.wemo.backend.domain.lightning.service.LightningService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -53,6 +54,19 @@ public class LightningController {
 
         return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.getLightningMeetingList(cursor, size, province, district,
                 lightningTypeId, lightningTimeId, latitude, longitude, radius)));
+    }
+
+    @Operation(summary = "번개 모임 상세조회", description = "요청한 번개 모임의 상세 정보를 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청한 번개 모임의 상세 정보가 반환되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임입니다.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{lightningId}", method = RequestMethod.GET)
+    public ResponseEntity<SuccessResponse<LightningDetailResponse>> getLightningMeetingDetail(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                                              @PathVariable Long lightningId) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.getLightningMeetingDetail(userDetails, lightningId)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningDetailResponse.java
@@ -1,0 +1,70 @@
+package com.wemo.backend.domain.lightning.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.wemo.backend.domain.lightning.entity.Lightning;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class LightningDetailResponse {
+
+    private Long lightningId;
+
+    private String lightningName;
+
+    private String lightningType;
+
+    private String lightningTime;
+
+    private LocalDateTime lightningDate;
+
+    private String address;
+
+    private String lightningContent;
+
+    private double latitude;
+
+    private double longitude;
+
+    private int lightningCapacity;
+
+    private String email;
+
+    private String nickname;
+
+    private String profileImagePath;
+
+    private boolean isJoined;
+
+    @JsonProperty("isJoined")
+    public boolean getIsJoined() {
+
+        return isJoined;
+    }
+
+    public static LightningDetailResponse fromEntity(Lightning lightning, boolean isJoined) {
+
+        return LightningDetailResponse.builder()
+                .lightningId(lightning.getId())
+                .lightningName(lightning.getLightningName())
+                .lightningType(lightning.getLightningType().getLightTypeName())
+                .lightningTime(lightning.getDateType().getName())
+                .lightningDate(lightning.getLightningDate())
+                .address(lightning.getAddress())
+                .lightningContent(lightning.getLightningContent())
+                .latitude(lightning.getLatitude())
+                .longitude(lightning.getLongitude())
+                .lightningCapacity(lightning.getLightningCapacity())
+                .email(lightning.getUser().getEmail())
+                .nickname(lightning.getUser().getNickname())
+                .profileImagePath(lightning.getUser().getProfileImagePath())
+                .isJoined(isJoined)
+                .build();
+    }
+
+}

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
@@ -1,8 +1,10 @@
 package com.wemo.backend.domain.lightning.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
+import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,5 +13,7 @@ public interface LightningService {
     LightningCreateResponse createLightnings(String email, LightningCreateRequest request);
 
     LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius);
+
+    LightningDetailResponse getLightningMeetingDetail(UserDetailsImpl userDetails, Long lightningId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
@@ -1,11 +1,14 @@
 package com.wemo.backend.domain.lightning.service;
 
+import com.wemo.backend.domain.auth.UserDetailsImpl;
 import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
 import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
+import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
 import com.wemo.backend.domain.lightning.repository.LightningRepository;
+import com.wemo.backend.domain.lightningJoin.repository.LightningJoinRepository;
 import com.wemo.backend.domain.lightningJoin.service.LightningJoinStore;
 import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
@@ -38,6 +41,10 @@ public class LightningServiceImpl implements LightningService {
 
     private final LightningRepository lightningRepository;
 
+    private final LightningReader lightningReader;
+
+    private final LightningJoinRepository lightningJoinRepository;
+
     /**
      * 번개 모임 생성
      *
@@ -49,7 +56,7 @@ public class LightningServiceImpl implements LightningService {
     @Transactional
     public LightningCreateResponse createLightnings(String email, LightningCreateRequest request) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         LightningType lightningType = lightningTypeReader.getLightningType(request.getLightningTypeId());
 
         Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(request.getAddress());
@@ -82,6 +89,30 @@ public class LightningServiceImpl implements LightningService {
     public LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius) {
 
         return lightningRepository.getLightningMeetingList(cursor, size, province, district, lightningTypeId, lightningTimeId, latitude, longitude, radius);
+    }
+
+    /**
+     * 번개 모임 상세 조회
+     *
+     * @param userDetails 유저 정보 객체
+     * @param lightningId 번개 모임 id
+     * @return 요청한 번개 모임 상세 정보
+     */
+    @Override
+    public LightningDetailResponse getLightningMeetingDetail(UserDetailsImpl userDetails, Long lightningId) {
+
+        // 번개 모임 유효성 검사 및 조회
+        Lightning lightning = lightningReader.getLightningById(lightningId);
+
+        // 회원인 경우 참여 내역 확인
+        if (userDetails != null && !userDetails.isGuest()) {
+            User user = userReader.getActiveUserByEmail(userDetails.getUsername());
+            boolean isJoined = lightningJoinRepository.existsByUserAndLightning(user, lightning);
+            return LightningDetailResponse.fromEntity(lightning, isJoined);
+        }
+
+        // 비회원인 경우 참여 내역 false
+        return LightningDetailResponse.fromEntity(lightning, false);
     }
 
     private Province getOrSaveProvince(String provinceName) {

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/service/LightningJoinServiceImpl.java
@@ -36,7 +36,7 @@ public class LightningJoinServiceImpl implements LightningJoinService {
     @Transactional
     public String participateLightningMeeting(String email, Long lightningId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Lightning lightning = lightningReader.getLightningById(lightningId);
 
         int currentParticipants = lightningJoinReader.getParticipantsCount(lightning);

--- a/src/main/java/com/wemo/backend/domain/like/service/LikeServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/like/service/LikeServiceImpl.java
@@ -34,7 +34,7 @@ public class LikeServiceImpl implements LikeService {
     public String likePlan(String email, Long planId) {
 
         // 유효성 검사
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         // 이미 좋아요를 누른 일정이라면 예외 반환
@@ -58,7 +58,7 @@ public class LikeServiceImpl implements LikeService {
     public String deleteLikePlan(String email, Long planId) {
 
         // 유효성 검사
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         // 좋아요를 누르지 않은 일정이라면 예외 반환

--- a/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/service/MeetingServiceImpl.java
@@ -103,7 +103,7 @@ public class MeetingServiceImpl implements MeetingService {
 
         boolean joined = false;
         if (userDetails != null && !userDetails.isGuest()) {
-            User user = userReader.getUserByEmail(userDetails.getUsername());
+            User user = userReader.getActiveUserByEmail(userDetails.getUsername());
             joined = meetingMemberStore.isAlreadyJoined(user, meeting);
         }
         return MeetingDetailResponse.fromEntity(
@@ -240,7 +240,7 @@ public class MeetingServiceImpl implements MeetingService {
     @Override
     public String joinCancelMeeting(String email, Long meetingId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Meeting meeting = meetingReader.getMeeting(meetingId);
 
         meetingMemberStore.deleteMember(user, meeting);
@@ -274,7 +274,7 @@ public class MeetingServiceImpl implements MeetingService {
      */
     private User validateUser(String email) {
 
-        return userReader.getUserByEmail(email);
+        return userReader.getActiveUserByEmail(email);
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/oauth/service/Oauth2ServiceImpl.java
@@ -174,7 +174,7 @@ public class Oauth2ServiceImpl implements Oauth2Service {
 
         User user;
         try {
-            user = userReader.getUserByEmail(email);
+            user = userReader.getActiveUserByEmail(email);
         } catch (CustomException e) {
             log.info("신규 유저 저장: 추가 데이터 필요, email : {}", email);
 

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -70,7 +70,7 @@ public class PlanServiceImpl implements PlanService {
     @Transactional
     public PlanCreateResponse createPlan(String email, PlanCreateRequest request, Long meetingId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Meeting meeting = meetingReader.getMeeting(meetingId);
 
         commUtilService.validateMeetingOwner(user, meeting);
@@ -115,7 +115,7 @@ public class PlanServiceImpl implements PlanService {
     @Transactional
     public String joinPlan(String email, Long planId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         attendanceStore.attendPlan(user, plan);
@@ -171,7 +171,7 @@ public class PlanServiceImpl implements PlanService {
         // 회원인 경우 참여 여부 판단
         if (userDetails != null && !userDetails.isGuest()) {
             String email = userDetails.getUsername();
-            User user = userReader.getUserByEmail(email);
+            User user = userReader.getActiveUserByEmail(email);
             existAttendance = attendanceReader.existAttendance(user, plan);
         }
 
@@ -197,7 +197,7 @@ public class PlanServiceImpl implements PlanService {
     @Transactional
     public String cancelPlan(String email, Long planId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         commUtilService.validateMeetingOwner(user, plan.getMeeting());
@@ -218,7 +218,7 @@ public class PlanServiceImpl implements PlanService {
     @Override
     public String cancelAttendance(String email, Long planId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         attendanceStore.quitPlan(user, plan);
@@ -246,7 +246,7 @@ public class PlanServiceImpl implements PlanService {
     @Transactional
     public UserPlanPagingResponse getLikedPlanList(String email, Pageable pageable, String query, String province, String district, String startDate, String endDate, Long categoryId, String sort) {
         // 사용자 검증
-        userReader.getUserByEmail(email);
+        userReader.getActiveUserByEmail(email);
         return new UserPlanPagingResponse(planRepository.getLikedPlanList(email, pageable, query, province, district, startDate, endDate, categoryId, sort));
     }
 
@@ -265,7 +265,7 @@ public class PlanServiceImpl implements PlanService {
         if (userDetails == null || userDetails.isGuest()) {
             return false;
         }
-        User user = userReader.getUserByEmail(userDetails.getUsername());
+        User user = userReader.getActiveUserByEmail(userDetails.getUsername());
         return likeRepository.existsByUserAndPlan(user, plan);
     }
 

--- a/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/review/service/ReviewServiceImpl.java
@@ -61,7 +61,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public ReviewCreateResponse createReview(String email, Long planId, ReviewCreateRequest request) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Plan plan = planReader.getPlan(planId);
 
         checkExistingReview(user, plan);
@@ -105,7 +105,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public ReviewCreateResponse updateReview(String email, Long reviewId, ReviewCreateRequest request) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Review review = reviewReader.getReview(reviewId);
         // 본인 후기인지 확인
         reviewReader.validateReview(user, review);
@@ -134,7 +134,7 @@ public class ReviewServiceImpl implements ReviewService {
     @Transactional
     public String deleteReview(String email, Long reviewId) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         Review review = reviewReader.getReview(reviewId);
         // 본인 후기인지 확인
         reviewReader.validateReview(user, review);

--- a/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/user/dto/UserPlanListResponse.java
@@ -56,9 +56,6 @@ public class UserPlanListResponse {
     @JsonProperty("isCanceled")
     private boolean isCanceled;
 
-    @JsonProperty("isFulled")
-    private boolean isFulled;
-
     @JsonProperty("isLiked")
     private boolean isLiked;
 
@@ -72,12 +69,6 @@ public class UserPlanListResponse {
     public boolean getIsOpened() {
 
         return isOpened;
-    }
-
-    @JsonProperty("isFulled")
-    public boolean getIsFulled() {
-
-        return isFulled;
     }
 
     @JsonProperty("isLiked")

--- a/src/main/java/com/wemo/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<User, UUID>, UserQueryDsl 
 
     Optional<User> findByEmail(String email);
 
+    Optional<User> findByEmailAndDeletedAtIsNull(String email);
+
     boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -59,11 +59,13 @@ public class UserQueryDslImpl implements UserQueryDsl {
 
         BooleanBuilder whereClause = new BooleanBuilder();
         whereClause.and(meeting.deletedAt.isNull());
-        whereClause.and(user.email.eq(email)); // ✅ user를 기준으로 필터링
+        whereClause.and(user.email.eq(email)); // user 기준으로 필터링
         if (isMyMeeting) {
-            whereClause.and(meeting.user.email.eq(email)); // ✅ 내가 만든 모임 조회
+            log.info("{}가 만든 모임 목록 조회 요청", email);
+            whereClause.and(meeting.user.email.eq(email)); // 내가 만든 모임 조회
         } else {
-            whereClause.and(meeting.user.email.ne(email)); // ✅ 가입된 모임 중 내가 만든 모임 제외
+            log.info("{}가 가입된 모임 목록 조회 요청", email);
+            whereClause.and(meeting.user.email.ne(email)); // 가입된 모임 중 내가 만든 모임 제외
         }
 
         List<UserMeetingListResponse> results = queryFactory
@@ -93,9 +95,9 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 meeting.updatedAt
                         )
                 )
-                .from(meetingMember)  // ✅ meetingMember 기준 조회
-                .join(meetingMember.meeting, meeting)  // ✅ meetingMember → meeting Join
-                .join(meetingMember.user, user)  // ✅ meetingMember → user Join
+                .from(meetingMember)
+                .join(meetingMember.meeting, meeting)
+                .join(meetingMember.user, user)
                 .where(whereClause)
                 .groupBy(meeting.id) // 그룹화
                 .orderBy(meeting.createdAt.desc())
@@ -128,13 +130,16 @@ public class UserQueryDslImpl implements UserQueryDsl {
     private Page<UserPlanListResponse> getPlanList(String email, Pageable pageable, boolean isMyPlan) {
 
         updateIsFulledStatus();
-        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9)); // KST 시간으로 현재 시간 얻기
+        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9));
 
         BooleanBuilder whereClause = new BooleanBuilder();
         whereClause.and(plan.deletedAt.isNull().and(plan.dateTime.after(nowKST)));
         if (isMyPlan) {
+            log.info("{}가 만든 일정 목록 조회 요청", email);
+
             whereClause.and(plan.user.email.eq(email));
         } else {
+            log.info("{}가 참여한 일정 목록 조회 요청", email);
             whereClause.and(plan.user.email.ne(email)) // 사용자가 만든 일정이 아니어야 함
                     .and(plan.id.in(
                             JPAExpressions.select(attendance.plan.id)
@@ -230,7 +235,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(plan.user, user)
                 .leftJoin(attendance).on(attendance.plan.eq(plan))
                 .where(whereClause)
-                .groupBy(plan.id) // 그룹화
+                .groupBy(plan.id)
                 .orderBy(plan.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -248,6 +253,8 @@ public class UserQueryDslImpl implements UserQueryDsl {
 
     @Override
     public Page<UserReviewListResponse> getUserReviewList(String email, Pageable pageable) {
+
+        log.info("{}의 작성한 후기 목록 조회 요청", email);
 
         JPAQuery<UserReviewListResponse> queryBuilder = queryFactory
                 .select(
@@ -321,6 +328,11 @@ public class UserQueryDslImpl implements UserQueryDsl {
     @Override
     public Page<UserPlanReviewableListResponse> getUserPlanListReviewAvailable(String email, Pageable pageable) {
 
+        log.info("{}의 후기 작성 가능한 일정 목록 조회 요청", email);
+
+        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9));
+        BooleanExpression isCompleted = plan.dateTime.before(nowKST);
+
         JPAQuery<UserPlanReviewableListResponse> queryBuilder = queryFactory
                 .select(
                         Projections.constructor(
@@ -357,6 +369,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                 .leftJoin(attendance.user, user)
                 .leftJoin(review).on(review.plan.id.eq(plan.id))
                 .where(
+                        isCompleted, // 이용 완료
                         attendance.user.email.eq(email), // 유저 참석 확인
                         attendance.reviewed.eq(false), // 후기 미작성 필터
                         plan.dateTime.before(LocalDateTime.now()), // 지난 일정만 조회
@@ -382,6 +395,7 @@ public class UserQueryDslImpl implements UserQueryDsl {
                         .leftJoin(attendance.user, user)
                         .leftJoin(review).on(review.plan.id.eq(plan.id))
                         .where(
+                                isCompleted, // 이용 완료
                                 attendance.user.email.eq(email), // 유저 참석 확인
                                 attendance.reviewed.eq(false), // 후기 미작성 필터
                                 plan.dateTime.before(LocalDateTime.now()), // 지난 일정만 조회
@@ -397,11 +411,10 @@ public class UserQueryDslImpl implements UserQueryDsl {
     @Override
     public UserPlanListForCalendar getUserPlanListForCalendar(String email, String startDate, String endDate) {
 
+        log.info("{}의 월별 일정 목록 조회 요청", email);
         updateIsFulledStatus();
 
-        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9)); // KST 시간으로 현재 시간 얻기
-        log.info("nowKST 현재 시각 : {}", nowKST);
-
+        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9));
         BooleanExpression isCompleted = plan.dateTime.before(nowKST);
 
         BooleanBuilder whereClause = new BooleanBuilder();

--- a/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/repository/querydsl/UserQueryDslImpl.java
@@ -128,9 +128,10 @@ public class UserQueryDslImpl implements UserQueryDsl {
     private Page<UserPlanListResponse> getPlanList(String email, Pageable pageable, boolean isMyPlan) {
 
         updateIsFulledStatus();
+        LocalDateTime nowKST = LocalDateTime.now(ZoneOffset.ofHours(9)); // KST 시간으로 현재 시간 얻기
 
         BooleanBuilder whereClause = new BooleanBuilder();
-        whereClause.and(plan.deletedAt.isNull());
+        whereClause.and(plan.deletedAt.isNull().and(plan.dateTime.after(nowKST)));
         if (isMyPlan) {
             whereClause.and(plan.user.email.eq(email));
         } else {
@@ -211,7 +212,6 @@ public class UserQueryDslImpl implements UserQueryDsl {
                                 plan.updatedAt,
                                 plan.opened,
                                 plan.canceled,
-                                plan.fulled,
                                 Expressions.as(
                                         queryFactory.select(likes.count())
                                                 .from(likes)

--- a/src/main/java/com/wemo/backend/domain/user/service/UserReader.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserReader.java
@@ -10,6 +10,8 @@ public interface UserReader {
 
     User getUserByEmail(String email);
 
+    User getActiveUserByEmail(String email);
+
     User getUser(String email, String password);
 
 }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserReaderImpl.java
@@ -57,6 +57,19 @@ public class UserReaderImpl implements UserReader {
     }
 
     /**
+     * 이메일로 활동 중인 유저 조회
+     *
+     * @param email 사용자 이메일
+     * @return 해당 유저 객체
+     */
+    @Override
+    public User getActiveUserByEmail(String email) {
+
+        return userRepository.findByEmailAndDeletedAtIsNull(email)
+                .orElseThrow(() -> new CustomException(USER_WITHDRAW));
+    }
+
+    /**
      * 유저 객체 검증
      *
      * @param email    사용자 아이디
@@ -66,7 +79,7 @@ public class UserReaderImpl implements UserReader {
     @Override
     public User getUser(String email, String password) {
 
-        User user = getUserByEmail(email); // 중복된 조회 로직을 재사용
+        User user = getActiveUserByEmail(email);
         validatePassword(password, user.getPassword());
         return user;
     }

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -92,7 +92,7 @@ public class UserServiceImpl implements UserService {
     @Override
     public void signin(SigninRequest signinRequest, HttpServletRequest request, HttpServletResponse response) {
 
-        // 유저 검증 및 객체 조회
+        // 유저 검증 및 객체 조회 (탈퇴한 유저의 정보와 같은 이메일로 로그인 하는 경우 예외 반환)
         User user = userReader.getUser(signinRequest.getEmail(), signinRequest.getPassword());
         log.info("사용자 {} 로그인 성공", user.getEmail());
 
@@ -151,6 +151,8 @@ public class UserServiceImpl implements UserService {
     @Override
     public UserMeetingPagingResponse getMeetingList(String email, Pageable pageable) {
 
+        userReader.getActiveUserByEmail(email);
+
         return new UserMeetingPagingResponse(userRepository.getUserMeetingList(email, pageable));
     }
 
@@ -163,6 +165,8 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public UserMeetingPagingResponse getMyMeetingList(String email, Pageable pageable) {
+
+        userReader.getActiveUserByEmail(email);
 
         return new UserMeetingPagingResponse(userRepository.getMyMeetingList(email, pageable));
     }
@@ -178,6 +182,8 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserPlanPagingResponse getPlanList(String email, Pageable pageable) {
 
+        userReader.getActiveUserByEmail(email);
+
         return new UserPlanPagingResponse(userRepository.getUserPlanList(email, pageable));
     }
 
@@ -192,6 +198,8 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserPlanPagingResponse getMyPlanList(String email, Pageable pageable) {
 
+        userReader.getActiveUserByEmail(email);
+
         return new UserPlanPagingResponse(userRepository.getMyPlanList(email, pageable));
     }
 
@@ -204,6 +212,8 @@ public class UserServiceImpl implements UserService {
      */
     @Override
     public UserReviewPagingResponse getMyReviewList(String email, Pageable pageable) {
+
+        userReader.getActiveUserByEmail(email);
 
         return new UserReviewPagingResponse(userRepository.getUserReviewList(email, pageable));
     }
@@ -219,6 +229,8 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserPlanPagingResponse getPlanListReviewAvailable(String email, Pageable pageable) {
 
+        userReader.getActiveUserByEmail(email);
+
         return new UserPlanPagingResponse(userRepository.getUserPlanListReviewAvailable(email, pageable));
     }
 
@@ -233,7 +245,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public UserUpdateResponse updateProfile(String email, UserUpdateRequest request) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
         User updateUser = user.update(request);
 
         return UserUpdateResponse.fromEntity(updateUser);
@@ -249,7 +261,7 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public void saveAdditionalUserData(String email, AdditionalDataRequest request) {
 
-        User user = userReader.getUserByEmail(email);
+        User user = userReader.getActiveUserByEmail(email);
 
         user.saveAdditionalData(request);
     }
@@ -264,8 +276,8 @@ public class UserServiceImpl implements UserService {
     @Transactional
     public String withdraw(String email) {
 
-        // 유저 객체 조회 및 softDelete 처리
-        User user = userReader.getUserByEmail(email);
+        // 유저 객체 조회 및 softDelete 처리 (이미 탈퇴한 유저의 경우 재탈퇴 불가)
+        User user = userReader.getActiveUserByEmail(email);
         user.softDelete();
         user.setDeletedUserNickname();
 
@@ -296,6 +308,8 @@ public class UserServiceImpl implements UserService {
     @Override
     @Transactional
     public UserPlanListForCalendar getUserPlanListForCalendar(String email, String startDate, String endDate) {
+
+        userReader.getActiveUserByEmail(email);
 
         return userRepository.getUserPlanListForCalendar(email, startDate, endDate);
     }

--- a/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/wemo/backend/global/config/SecurityConfig.java
@@ -53,7 +53,8 @@ public class SecurityConfig {
 
                     configuration.setAllowedOrigins(Arrays.asList(
                             "http://localhost:3000",
-                            "https://we-mo.store"
+                            "https://we-mo.store",
+                            "https://sub-domain.we-mo.store"
                     ));
                     configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
                     configuration.setAllowCredentials(true);

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
     EMAIL_ALREADY_IN_USE(HttpStatus.CONFLICT, "이미 사용 중인 이메일 입니다."),
     INVALID_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "가입되지 않은 아이디입니다."),
+    USER_WITHDRAW(HttpStatus.BAD_REQUEST, "탈퇴한 사용자입니다."),
 
     // Token
     REFRESH_TOKEN_NOT_PROVIDED(HttpStatus.BAD_REQUEST, "refreshToken이 요청에 포함되지 않았습니다."),


### PR DESCRIPTION
## 📌 작업 내용

### 🔄 변경 사항
- **유저 객체 조회 메서드**: 활동 중인 유저만 조회되도록 수정
- **일정 목록 조회**:
  - 내가 참여한 및 만든 일정 목록에서 **이용 예정인 일정**만 조회하도록 변경
  - 후기 작성 가능한 일정 목록에서 **이용 완료된 일정**만 조회하도록 수정
- **CORS 설정**: `https://sub-domain.we-mo-store` 추가
- **CI/CD 개선**: 불필요한 CI 과정 제거 및 무중단 배포를 위한 CD 수정

### ✨ 추가된 기능
- **번개 모임 상세 조회 기능** 구현

<br>

## 🌱 반영 브랜치
- `feat/lightning-detail-148` -> `dev`
- close #148

<br>

## 🔥 트러블슈팅
- **CI/CD 문제**: CI 처리 시간이 길어 CD가 먼저 완료되고 최신화된 코드가 배포 환경에 반영되지 않는 문제 발생
- **해결 방법**: CI 종료 후 CD가 진행되도록 설정을 수정하여 문제 해결

<br>
