### PR TITLE
[Feat] 번개 모임 수정 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
@@ -1,10 +1,10 @@
 package com.wemo.backend.domain.lightning.controller;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
-import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
-import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
+import com.wemo.backend.domain.lightning.dto.LightningResponse;
 import com.wemo.backend.domain.lightning.service.LightningService;
 import com.wemo.backend.global.response.SuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -33,8 +33,8 @@ public class LightningController {
                     content = @Content(mediaType = "application/json"))
     })
     @RequestMapping(value = "", method = RequestMethod.POST)
-    public ResponseEntity<SuccessResponse<LightningCreateResponse>> createLightnings(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                                                                     @Valid @RequestBody LightningCreateRequest request) {
+    public ResponseEntity<SuccessResponse<LightningResponse>> createLightnings(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                               @Valid @RequestBody LightningRequest request) {
 
         return ResponseEntity.status(201).body(SuccessResponse.successWithData(lightningService.createLightnings(userDetails.getUsername(), request)));
     }
@@ -67,6 +67,20 @@ public class LightningController {
                                                                                               @PathVariable Long lightningId) {
 
         return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.getLightningMeetingDetail(userDetails, lightningId)));
+    }
+
+    @Operation(summary = "번개 모임 수정", description = "번개 모임 정보를 수정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "번개 모임 정보가 수정되었습니다."),
+            @ApiResponse(responseCode = "400", description = "입력값을 확인해주세요.",
+                    content = @Content(mediaType = "application/json"))
+    })
+    @RequestMapping(value = "/{lightningId}", method = RequestMethod.PUT)
+    public ResponseEntity<SuccessResponse<LightningResponse>> updateLightnings(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                               @PathVariable Long lightningId,
+                                                                               @Valid @RequestBody LightningRequest lightningRequest) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.updateLightnings(userDetails.getUsername(), lightningId, lightningRequest)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningDetailResponse.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningDetailResponse.java
@@ -47,6 +47,10 @@ public class LightningDetailResponse {
         return isJoined;
     }
 
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
     public static LightningDetailResponse fromEntity(Lightning lightning, boolean isJoined) {
 
         return LightningDetailResponse.builder()
@@ -64,6 +68,8 @@ public class LightningDetailResponse {
                 .nickname(lightning.getUser().getNickname())
                 .profileImagePath(lightning.getUser().getProfileImagePath())
                 .isJoined(isJoined)
+                .createdAt(lightning.getCreatedAt())
+                .updatedAt(lightning.getUpdatedAt())
                 .build();
     }
 

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningRequest.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningRequest.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 @AllArgsConstructor
-public class LightningCreateRequest {
+public class LightningRequest {
 
     @NotBlank(message = "모임명은 필수 입력 값입니다.")
     private String lightningName;

--- a/src/main/java/com/wemo/backend/domain/lightning/dto/LightningResponse.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/dto/LightningResponse.java
@@ -10,7 +10,9 @@ import java.time.LocalDateTime;
 @Getter
 @Builder
 @AllArgsConstructor
-public class LightningCreateResponse {
+public class LightningResponse {
+
+    private Long lightningId;
 
     private String lightningName;
 
@@ -30,9 +32,10 @@ public class LightningCreateResponse {
 
     private int lightningCapacity;
 
-    public static LightningCreateResponse fromEntity(Lightning lightning) {
+    public static LightningResponse fromEntity(Lightning lightning) {
 
-        return LightningCreateResponse.builder()
+        return LightningResponse.builder()
+                .lightningId(lightning.getId())
                 .lightningName(lightning.getLightningName())
                 .lightningType(lightning.getLightningType().getLightTypeName())
                 .lightningTime(lightning.getDateType().getName())

--- a/src/main/java/com/wemo/backend/domain/lightning/entity/Lightning.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/entity/Lightning.java
@@ -1,5 +1,6 @@
 package com.wemo.backend.domain.lightning.entity;
 
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
 import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.entity.Timestamped;
@@ -73,5 +74,19 @@ public class Lightning extends Timestamped {
     @Column(name = "longitude", nullable = false)
     @Comment("경도")
     private double longitude;
+
+    public void update(LightningRequest request, LightningType lightningType, District district) {
+
+        this.lightningName = request.getLightningName();
+        this.lightningType = lightningType;
+        this.dateType = DateType.fromId(request.getDateTypeId());
+        this.lightningDate = request.getLightningDate();
+        this.lightningContent = request.getLightningContent();
+        this.lightningCapacity = request.getLightningCapacity();
+        this.address = request.getAddress();
+        this.district = district;
+        this.latitude = request.getLatitude();
+        this.longitude = request.getLongitude();
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningReader.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningReader.java
@@ -2,9 +2,12 @@ package com.wemo.backend.domain.lightning.service;
 
 
 import com.wemo.backend.domain.lightning.entity.Lightning;
+import com.wemo.backend.domain.user.entity.User;
 
 public interface LightningReader {
-    
+
     Lightning getLightningById(Long lightningId);
+
+    void validLightningUser(User user, Lightning lightning);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningReaderImpl.java
@@ -2,11 +2,13 @@ package com.wemo.backend.domain.lightning.service;
 
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.repository.LightningRepository;
+import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.global.exception.CustomException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import static com.wemo.backend.global.exception.ErrorCode.LIGHTNING_MEETING_NOT_FOUND;
+import static com.wemo.backend.global.exception.ErrorCode.LIGHTNING_PERMISSION_DENIED;
 
 @Component
 @RequiredArgsConstructor
@@ -20,6 +22,13 @@ public class LightningReaderImpl implements LightningReader {
         return lightningRepository.findById(lightningId).orElseThrow(
                 () -> new CustomException(LIGHTNING_MEETING_NOT_FOUND)
         );
+    }
+
+    @Override
+    public void validLightningUser(User user, Lightning lightning) {
+
+        if (lightning.getUser() != user) throw new CustomException(LIGHTNING_PERMISSION_DENIED);
+
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
@@ -1,19 +1,21 @@
 package com.wemo.backend.domain.lightning.service;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
-import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
-import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
+import com.wemo.backend.domain.lightning.dto.LightningResponse;
 import org.springframework.stereotype.Service;
 
 @Service
 public interface LightningService {
 
-    LightningCreateResponse createLightnings(String email, LightningCreateRequest request);
+    LightningResponse createLightnings(String email, LightningRequest request);
 
     LightningCursorPagingResponse getLightningMeetingList(Long cursor, int size, String province, String district, Long lightningTypeId, Integer lightningTimeId, Double latitude, Double longitude, Double radius);
 
     LightningDetailResponse getLightningMeetingDetail(UserDetailsImpl userDetails, Long lightningId);
+
+    LightningResponse updateLightnings(String email, Long lightningId, LightningRequest lightningRequest);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
@@ -1,10 +1,10 @@
 package com.wemo.backend.domain.lightning.service;
 
 import com.wemo.backend.domain.auth.UserDetailsImpl;
-import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
-import com.wemo.backend.domain.lightning.dto.LightningCreateResponse;
 import com.wemo.backend.domain.lightning.dto.LightningCursorPagingResponse;
 import com.wemo.backend.domain.lightning.dto.LightningDetailResponse;
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
+import com.wemo.backend.domain.lightning.dto.LightningResponse;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
 import com.wemo.backend.domain.lightning.repository.LightningRepository;
@@ -54,7 +54,7 @@ public class LightningServiceImpl implements LightningService {
      */
     @Override
     @Transactional
-    public LightningCreateResponse createLightnings(String email, LightningCreateRequest request) {
+    public LightningResponse createLightnings(String email, LightningRequest request) {
 
         User user = userReader.getActiveUserByEmail(email);
         LightningType lightningType = lightningTypeReader.getLightningType(request.getLightningTypeId());
@@ -68,7 +68,7 @@ public class LightningServiceImpl implements LightningService {
         // 주최자는 자동 참여
         lightningJoinStore.store(user, lightning);
 
-        return LightningCreateResponse.fromEntity(lightning);
+        return LightningResponse.fromEntity(lightning);
     }
 
     /**
@@ -113,6 +113,34 @@ public class LightningServiceImpl implements LightningService {
 
         // 비회원인 경우 참여 내역 false
         return LightningDetailResponse.fromEntity(lightning, false);
+    }
+
+    /**
+     * 번개 모임 수정
+     *
+     * @param email            사용자 이메일
+     * @param lightningId      번개 모임 id
+     * @param lightningRequest 수정 요청 데이터
+     * @return 수정된 번개 모임 데이터
+     */
+    @Override
+    @Transactional
+    public LightningResponse updateLightnings(String email, Long lightningId, LightningRequest lightningRequest) {
+
+        User user = userReader.getActiveUserByEmail(email);
+        Lightning lightning = lightningReader.getLightningById(lightningId);
+
+        // 본인이 생성한 모임인지 검증
+        lightningReader.validLightningUser(user, lightning);
+
+        LightningType lightningType = lightningTypeReader.getLightningType(lightningRequest.getLightningTypeId());
+        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(lightningRequest.getAddress());
+        Province province = getOrSaveProvince(parsedAddress.get("province"));
+        District district = getOrSaveDistrict(parsedAddress.get("district"), province);
+
+        lightning.update(lightningRequest, lightningType, district);
+
+        return LightningResponse.fromEntity(lightning);
     }
 
     private Province getOrSaveProvince(String provinceName) {

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
@@ -1,6 +1,6 @@
 package com.wemo.backend.domain.lightning.service;
 
-import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
 import com.wemo.backend.domain.region.entity.District;
@@ -8,6 +8,6 @@ import com.wemo.backend.domain.user.entity.User;
 
 public interface LightningStore {
 
-    Lightning store(User user, LightningType lightningType, District district, LightningCreateRequest request);
+    Lightning store(User user, LightningType lightningType, District district, LightningRequest request);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
@@ -1,6 +1,6 @@
 package com.wemo.backend.domain.lightning.service;
 
-import com.wemo.backend.domain.lightning.dto.LightningCreateRequest;
+import com.wemo.backend.domain.lightning.dto.LightningRequest;
 import com.wemo.backend.domain.lightning.entity.DateType;
 import com.wemo.backend.domain.lightning.entity.Lightning;
 import com.wemo.backend.domain.lightning.entity.LightningType;
@@ -19,7 +19,7 @@ public class LightningStoreImpl implements LightningStore {
 
     @Override
     @Transactional
-    public Lightning store(User user, LightningType lightningType, District district, LightningCreateRequest request) {
+    public Lightning store(User user, LightningType lightningType, District district, LightningRequest request) {
 
         Lightning lightning = Lightning.builder()
                 .user(user)

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingCreateResponse.java
@@ -14,6 +14,8 @@ public class MeetingCreateResponse {
 
     private String meetingName;
 
+    private String category;
+
     private String description;
 
     private List<String> meetingImagePath;
@@ -23,6 +25,7 @@ public class MeetingCreateResponse {
         return MeetingCreateResponse.builder()
                 .meetingId(meeting.getId())
                 .meetingName(meeting.getMeetingName())
+                .category(meeting.getCategory().getCategoryName())
                 .description(meeting.getDescription())
                 .meetingImagePath(meetingImagePath)
                 .build();

--- a/src/main/java/com/wemo/backend/domain/user/service/UserReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserReaderImpl.java
@@ -79,7 +79,7 @@ public class UserReaderImpl implements UserReader {
     @Override
     public User getUser(String email, String password) {
 
-        User user = getActiveUserByEmail(email);
+        User user = getUserByEmail(email);
         validatePassword(password, user.getPassword());
         return user;
     }

--- a/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/wemo/backend/global/exception/ErrorCode.java
@@ -59,8 +59,8 @@ public enum ErrorCode {
     // Lightning
     LIGHTNING_MEETING_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 번개 모임입니다."),
     ALREADY_JOINED_LIGHTNING_MEETING(HttpStatus.BAD_REQUEST, "이미 참여된 모임입니다."),
-    LIGHTNING_MEETING_IS_FULL(HttpStatus.BAD_REQUEST, "정원이 마감된 모임입니다.");
-
+    LIGHTNING_MEETING_IS_FULL(HttpStatus.BAD_REQUEST, "정원이 마감된 모임입니다."),
+    LIGHTNING_PERMISSION_DENIED(HttpStatus.UNAUTHORIZED, "본인이 생성한 모임만 수정/삭제 가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용 (필수)
### 🔄 변경된 내용
- 가입되지 않은 id 로 로그인 시 적절한 오류 메세지가 반환되도록 수정하였습니다.
- 모임 생성 후 응답 데이터에 카테고리 데이터 추가 반환했습니다.
- 번개 모임 상세 조회 시 생성일자와 수정일자 데이터 추가하였습니다.

### ✨ 추가된 내용
- 번개 모임 수정 기능 추가하였습니다.
- 생성자가 아닌 경우 권한이 없다는 메세지와 401을 반환합니다.
- 존재하는 모임이 아닌 경우 응답 메세지와 400을 반환합니다.


<br/>

## 🌱 반영 브랜치
- `feat/lightning-update-155` -> `dev`
- close #155 

<br/>
