### PR TITLE
[Feat] 번개 모임 삭제 기능 구현

### DIFF
--- a/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/controller/LightningController.java
@@ -78,9 +78,18 @@ public class LightningController {
     @RequestMapping(value = "/{lightningId}", method = RequestMethod.PUT)
     public ResponseEntity<SuccessResponse<LightningResponse>> updateLightnings(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                                                                @PathVariable Long lightningId,
-                                                                               @Valid @RequestBody LightningRequest lightningRequest) {
+                                                                               @Valid @RequestBody LightningRequest request) {
 
-        return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.updateLightnings(userDetails.getUsername(), lightningId, lightningRequest)));
+        return ResponseEntity.ok(SuccessResponse.successWithData(lightningService.updateLightnings(userDetails.getUsername(), lightningId, request)));
+    }
+
+    @Operation(summary = "번개 모임 삭제", description = "번개 모임을 삭제합니다.")
+    @ApiResponse(responseCode = "200", description = "번개 모임이 삭제되었습니다.")
+    @RequestMapping(value = "/{lightningId}", method = RequestMethod.DELETE)
+    public ResponseEntity<SuccessResponse<String>> deleteLightningMeeting(@AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                                          @PathVariable Long lightningId) {
+
+        return ResponseEntity.ok(SuccessResponse.successWithNoData(lightningService.deleteLightningMeeting(userDetails.getUsername(), lightningId)));
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningReader.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningReader.java
@@ -8,6 +8,6 @@ public interface LightningReader {
 
     Lightning getLightningById(Long lightningId);
 
-    void validLightningUser(User user, Lightning lightning);
+    Lightning validateLightningOwnership(User user, Long lightning);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningReaderImpl.java
@@ -25,10 +25,13 @@ public class LightningReaderImpl implements LightningReader {
     }
 
     @Override
-    public void validLightningUser(User user, Lightning lightning) {
+    public Lightning validateLightningOwnership(User user, Long lightningId) {
 
-        if (lightning.getUser() != user) throw new CustomException(LIGHTNING_PERMISSION_DENIED);
+        Lightning lightningById = getLightningById(lightningId);
 
+        if (lightningById.getUser() != user) throw new CustomException(LIGHTNING_PERMISSION_DENIED);
+
+        return lightningById;
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningService.java
@@ -16,6 +16,8 @@ public interface LightningService {
 
     LightningDetailResponse getLightningMeetingDetail(UserDetailsImpl userDetails, Long lightningId);
 
-    LightningResponse updateLightnings(String email, Long lightningId, LightningRequest lightningRequest);
+    LightningResponse updateLightnings(String email, Long lightningId, LightningRequest request);
+
+    String deleteLightningMeeting(String email, Long lightningId);
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningServiceImpl.java
@@ -11,18 +11,15 @@ import com.wemo.backend.domain.lightning.repository.LightningRepository;
 import com.wemo.backend.domain.lightningJoin.repository.LightningJoinRepository;
 import com.wemo.backend.domain.lightningJoin.service.LightningJoinStore;
 import com.wemo.backend.domain.region.entity.District;
-import com.wemo.backend.domain.region.entity.Province;
-import com.wemo.backend.domain.region.repository.DistrictRepository;
-import com.wemo.backend.domain.region.repository.ProvinceRepository;
-import com.wemo.backend.domain.region.service.RegionServiceImpl;
+import com.wemo.backend.domain.region.service.RegionStore;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.service.UserReader;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Map;
-
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class LightningServiceImpl implements LightningService {
@@ -31,9 +28,7 @@ public class LightningServiceImpl implements LightningService {
 
     private final LightningTypeReader lightningTypeReader;
 
-    private final ProvinceRepository provinceRepository;
-
-    private final DistrictRepository districtRepository;
+    private final RegionStore regionStore;
 
     private final LightningStore lightningStore;
 
@@ -58,15 +53,13 @@ public class LightningServiceImpl implements LightningService {
 
         User user = userReader.getActiveUserByEmail(email);
         LightningType lightningType = lightningTypeReader.getLightningType(request.getLightningTypeId());
-
-        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(request.getAddress());
-        Province province = getOrSaveProvince(parsedAddress.get("province"));
-        District district = getOrSaveDistrict(parsedAddress.get("district"), province);
-
+        District district = regionStore.parseAndGetDistrict(request.getAddress());
         Lightning lightning = lightningStore.store(user, lightningType, district, request);
 
+        log.info("번개 모임 생성 - 모임 ID: {}, 사용자: {}", lightning.getId(), email);
         // 주최자는 자동 참여
         lightningJoinStore.store(user, lightning);
+        log.info("번개 모임 자동 가입 - 모임 ID: {}, 사용자: {}", lightning.getId(), email);
 
         return LightningResponse.fromEntity(lightning);
     }
@@ -101,6 +94,7 @@ public class LightningServiceImpl implements LightningService {
     @Override
     public LightningDetailResponse getLightningMeetingDetail(UserDetailsImpl userDetails, Long lightningId) {
 
+        log.info("번개 모임 상세 조회 - 모임 ID: {}", lightningId);
         // 번개 모임 유효성 검사 및 조회
         Lightning lightning = lightningReader.getLightningById(lightningId);
 
@@ -118,42 +112,50 @@ public class LightningServiceImpl implements LightningService {
     /**
      * 번개 모임 수정
      *
-     * @param email            사용자 이메일
-     * @param lightningId      번개 모임 id
-     * @param lightningRequest 수정 요청 데이터
+     * @param email       사용자 이메일
+     * @param lightningId 번개 모임 id
+     * @param request     수정 요청 데이터
      * @return 수정된 번개 모임 데이터
      */
     @Override
     @Transactional
-    public LightningResponse updateLightnings(String email, Long lightningId, LightningRequest lightningRequest) {
+    public LightningResponse updateLightnings(String email, Long lightningId, LightningRequest request) {
 
+        // 유저 및 모임 권한 검증
         User user = userReader.getActiveUserByEmail(email);
-        Lightning lightning = lightningReader.getLightningById(lightningId);
+        Lightning lightning = lightningReader.validateLightningOwnership(user, lightningId);
 
-        // 본인이 생성한 모임인지 검증
-        lightningReader.validLightningUser(user, lightning);
+        LightningType lightningType = lightningTypeReader.getLightningType(request.getLightningTypeId());
+        District district = regionStore.parseAndGetDistrict(request.getAddress());
 
-        LightningType lightningType = lightningTypeReader.getLightningType(lightningRequest.getLightningTypeId());
-        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(lightningRequest.getAddress());
-        Province province = getOrSaveProvince(parsedAddress.get("province"));
-        District district = getOrSaveDistrict(parsedAddress.get("district"), province);
+        lightning.update(request, lightningType, district);
 
-        lightning.update(lightningRequest, lightningType, district);
+        log.info("번개 모임 수정 - 모임 ID: {}, 사용자: {}", lightning.getId(), email);
 
         return LightningResponse.fromEntity(lightning);
     }
 
-    private Province getOrSaveProvince(String provinceName) {
+    /**
+     * 번개 모임 삭제
+     *
+     * @param email       사용자 이메일
+     * @param lightningId 번개 모임 id
+     * @return 응답 메세지
+     */
+    @Override
+    @Transactional
+    public String deleteLightningMeeting(String email, Long lightningId) {
 
-        return provinceRepository.findByProvinceName(provinceName)
-                .orElseGet(() -> provinceRepository.save(new Province(provinceName)));
+        // 유저 및 모임 권한 검증
+        User user = userReader.getActiveUserByEmail(email);
+        Lightning lightning = lightningReader.validateLightningOwnership(user, lightningId);
+
+        lightningJoinRepository.deleteAllByLightning(lightning);
+        lightningStore.delete(lightning);
+
+        log.info("번개 모임 삭제 - 모임 ID: {}, 사용자: {}", lightning.getId(), email);
+
+        return "번개 모임이 성공적으로 삭제되었습니다.";
     }
-
-    private District getOrSaveDistrict(String districtName, Province province) {
-
-        return districtRepository.findByDistrictNameAndProvince(districtName, province)
-                .orElseGet(() -> districtRepository.save(new District(districtName, province)));
-    }
-
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStore.java
@@ -10,4 +10,6 @@ public interface LightningStore {
 
     Lightning store(User user, LightningType lightningType, District district, LightningRequest request);
 
+    void delete(Lightning lightning);
+
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/service/LightningStoreImpl.java
@@ -39,4 +39,10 @@ public class LightningStoreImpl implements LightningStore {
 
     }
 
+    @Override
+    public void delete(Lightning lightning) {
+
+        lightningRepository.delete(lightning);
+    }
+
 }

--- a/src/main/java/com/wemo/backend/domain/lightningJoin/repository/LightningJoinRepository.java
+++ b/src/main/java/com/wemo/backend/domain/lightningJoin/repository/LightningJoinRepository.java
@@ -5,10 +5,16 @@ import com.wemo.backend.domain.lightningJoin.entity.LightningJoin;
 import com.wemo.backend.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LightningJoinRepository extends JpaRepository<LightningJoin, Long> {
 
     boolean existsByUserAndLightning(User user, Lightning lightning);
 
     long countByLightning(Lightning lightning);
+
+    List<LightningJoin> findAllByLightning(Lightning lightning);
+
+    void deleteAllByLightning(Lightning lightning);
 
 }

--- a/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/service/PlanServiceImpl.java
@@ -20,10 +20,7 @@ import com.wemo.backend.domain.plan.dto.PlanDetailResponse;
 import com.wemo.backend.domain.plan.entity.Plan;
 import com.wemo.backend.domain.plan.repository.PlanRepository;
 import com.wemo.backend.domain.region.entity.District;
-import com.wemo.backend.domain.region.entity.Province;
-import com.wemo.backend.domain.region.repository.DistrictRepository;
-import com.wemo.backend.domain.region.repository.ProvinceRepository;
-import com.wemo.backend.domain.region.service.RegionServiceImpl;
+import com.wemo.backend.domain.region.service.RegionStore;
 import com.wemo.backend.domain.user.dto.UserListInfo;
 import com.wemo.backend.domain.user.dto.UserPlanPagingResponse;
 import com.wemo.backend.domain.user.entity.User;
@@ -35,7 +32,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 @Slf4j
@@ -45,8 +41,7 @@ public class PlanServiceImpl implements PlanService {
 
     private final UserReader userReader;
     private final MeetingReader meetingReader;
-    private final ProvinceRepository provinceRepository;
-    private final DistrictRepository districtRepository;
+    private final RegionStore regionStore;
     private final ImageStore imageStore;
     private final PlanStore planStore;
     private final PlanReader planReader;
@@ -75,9 +70,7 @@ public class PlanServiceImpl implements PlanService {
 
         commUtilService.validateMeetingOwner(user, meeting);
 
-        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(request.getAddress());
-        Province province = getOrSaveProvince(parsedAddress.get("province"));
-        District district = getOrSaveDistrict(parsedAddress.get("district"), province);
+        District district = regionStore.parseAndGetDistrict(request.getAddress());
 
         Plan plan = planStore.storePlan(request, district, user, meeting);
         log.info("일정 id {} 저장 완료", plan.getId());
@@ -90,18 +83,6 @@ public class PlanServiceImpl implements PlanService {
         }
 
         return PlanCreateResponse.fromEntity(plan, meeting);
-    }
-
-    private Province getOrSaveProvince(String provinceName) {
-
-        return provinceRepository.findByProvinceName(provinceName)
-                .orElseGet(() -> provinceRepository.save(new Province(provinceName)));
-    }
-
-    private District getOrSaveDistrict(String districtName, Province province) {
-
-        return districtRepository.findByDistrictNameAndProvince(districtName, province)
-                .orElseGet(() -> districtRepository.save(new District(districtName, province)));
     }
 
     /**

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionReaderImpl.java
@@ -1,6 +1,5 @@
 package com.wemo.backend.domain.region.service;
 
-import com.wemo.backend.domain.region.dto.ProvinceListResponse;
 import com.wemo.backend.domain.region.entity.District;
 import com.wemo.backend.domain.region.entity.Province;
 import com.wemo.backend.domain.region.repository.DistrictRepository;

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionServiceImpl.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import static com.wemo.backend.global.exception.ErrorCode.INVALID_ADDRESS;
 
-
 @Service
 @RequiredArgsConstructor
 public class RegionServiceImpl implements RegionService {

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionStore.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionStore.java
@@ -1,0 +1,9 @@
+package com.wemo.backend.domain.region.service;
+
+import com.wemo.backend.domain.region.entity.District;
+
+public interface RegionStore {
+
+    District parseAndGetDistrict(String address);
+
+}

--- a/src/main/java/com/wemo/backend/domain/region/service/RegionStoreImpl.java
+++ b/src/main/java/com/wemo/backend/domain/region/service/RegionStoreImpl.java
@@ -1,0 +1,40 @@
+package com.wemo.backend.domain.region.service;
+
+import com.wemo.backend.domain.region.entity.District;
+import com.wemo.backend.domain.region.entity.Province;
+import com.wemo.backend.domain.region.repository.DistrictRepository;
+import com.wemo.backend.domain.region.repository.ProvinceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+public class RegionStoreImpl implements RegionStore {
+
+    private final ProvinceRepository provinceRepository;
+
+    private final DistrictRepository districtRepository;
+
+    @Override
+    public District parseAndGetDistrict(String address) {
+
+        Map<String, String> parsedAddress = RegionServiceImpl.parseAddress(address);
+        Province province = findOrCreateProvince(parsedAddress.get("province"));
+        return findOrCreateDistrict(parsedAddress.get("district"), province);
+    }
+
+    private Province findOrCreateProvince(String provinceName) {
+
+        return provinceRepository.findByProvinceName(provinceName)
+                .orElseGet(() -> provinceRepository.save(new Province(provinceName)));
+    }
+
+    private District findOrCreateDistrict(String districtName, Province province) {
+
+        return districtRepository.findByDistrictNameAndProvince(districtName, province)
+                .orElseGet(() -> districtRepository.save(new District(districtName, province)));
+    }
+
+}


### PR DESCRIPTION
## 📌 작업 내용 (필수)

### 🔄 변경된 내용
- **지역 데이터 저장 로직 통합**: 일정 생성 및 번개 모임 생성 시 중복되었던 지역 데이터 저장 로직을 공통 메서드로 분리하여 재사용성을 높였습니다.
- **유저 권한 검증 로직 개선**: 기존 유저가 생성한 번개 모임인지 검증하는 로직에 번개 모임의 유효성 검사를 추가하여 코드의 가독성과 안정성을 향상시켰습니다.
- **로그 개선**: 번개 모임 기능별로 적절한 로그를 추가하여 추후 디버깅 및 모니터링이 용이하도록 했습니다.

### ✨ 추가된 내용
- **번개 모임 삭제 기능 구현**: 유저가 생성한 번개 모임을 삭제할 수 있는 기능을 추가하였습니다.

<br>

## 🌱 반영 브랜치
- `feat/lightning-delete-157` → `dev`
- close #157

<br>