### PR TITLE
[Refactor] 모임 목록 조회 응답 형태 수정

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtAuthenticationFilter.java
@@ -135,6 +135,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 uri -> uri.equals("/api/lightnings") || uri.startsWith("/api/lightnings?"), req -> true,
                 uri -> uri.matches("^/api/lightnings/\\d+$"), req -> accessToken == null,
                 uri -> uri.startsWith("/api/meetings"), req -> accessToken == null,
+                uri -> uri.matches("^/api/meetings/\\d+$"), req -> accessToken == null,
                 uri -> uri.startsWith("/api/plans") && !uri.contains("like"), req -> accessToken == null,
                 uri -> uri.startsWith("/api/reviews"), req -> true
         );

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListPlanListResponse.java
@@ -14,20 +14,14 @@ public class MeetingListPlanListResponse {
 
     private Long meetingId;
 
-    private String planName;
-
     private LocalDateTime dateTime;
 
-    private Long participants;
-
-    private int capacity;
-
-    private String planImagePath;
-
-    @JsonProperty("isOpened")
-    private boolean isOpened;
+    private boolean isFulled;
 
     @JsonProperty("isFulled")
-    private boolean isFulled;
+    public boolean getIsFulled() {
+
+        return isFulled;
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponseV2.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingListResponseV2.java
@@ -23,9 +23,11 @@ public class MeetingListResponseV2 {
 
     private String category;
 
+    private Long planCount;
+
     private List<MeetingListPlanListResponse> planList;
 
-    public MeetingListResponseV2(String email, Long meetingId, String meetingName, String description, String meetingImagePath, Long memberCount, String category) {
+    public MeetingListResponseV2(String email, Long meetingId, String meetingName, String description, String meetingImagePath, Long memberCount, String category, Long planCount) {
 
         this.email = email;
         this.meetingId = meetingId;
@@ -34,6 +36,7 @@ public class MeetingListResponseV2 {
         this.meetingImagePath = meetingImagePath;
         this.memberCount = memberCount;
         this.category = category;
+        this.planCount = planCount;
     }
 
     public void setPlanList(List<MeetingListPlanListResponse> planListResponses) {

--- a/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanListResponse.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/dto/MeetingPlanListResponse.java
@@ -22,10 +22,20 @@ public class MeetingPlanListResponse {
 
     private String planImagePath;
 
-    @JsonProperty("isOpened")
     private boolean isOpened;
 
-    @JsonProperty("isFulled")
+    @JsonProperty("isOpened")
+    public boolean getIsOpened() {
+
+        return isOpened;
+    }
+
     private boolean isFulled;
+
+    @JsonProperty("isFulled")
+    public boolean getIsFulled() {
+
+        return isFulled;
+    }
 
 }

--- a/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/meeting/repository/MeetingQueryDslImpl.java
@@ -259,7 +259,15 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                                                 .and(meetingMember.deletedAt.isNull())),
                                 "memberCount"
                         ),
-                        meeting.category.categoryName
+                        meeting.category.categoryName,
+                        Expressions.as(
+                                JPAExpressions.select(plan.count())
+                                        .from(plan)
+                                        .where(plan.meeting.eq(meeting)
+                                                .and(plan.canceled.eq(false))
+                                                .and(plan.deletedAt.isNull())),
+                                "planCount"
+                        )
                 ))
                 .from(meeting)
                 .leftJoin(meeting.user, user)
@@ -283,25 +291,7 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                         MeetingListPlanListResponse.class,
                         plan.id,
                         plan.meeting.id,
-                        plan.planName,
                         plan.dateTime,
-                        Expressions.as(
-                                queryFactory.select(attendance.count())
-                                        .from(attendance)
-                                        .where(attendance.plan.id.eq(plan.id)
-                                                .and(attendance.deletedAt.isNull())),
-                                "participants"
-                        ),
-                        plan.capacity,
-                        Expressions.as(
-                                queryFactory.select(image.fileUrl)
-                                        .from(image)
-                                        .where(image.entityId.eq(plan.id),
-                                                image.entityType.eq(Image.EntityType.PLAN),
-                                                image.main.eq(true)),
-                                "planImagePath"
-                        ),
-                        plan.opened,
                         plan.fulled
                 ))
                 .from(plan)
@@ -312,13 +302,13 @@ public class MeetingQueryDslImpl implements MeetingQueryDsl {
                 .collect(Collectors.groupingBy(
                         MeetingListPlanListResponse::getMeetingId,
                         LinkedHashMap::new,
-                        Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().limit(3).toList())
+                        Collectors.collectingAndThen(Collectors.toList(), list -> list.stream().limit(4).toList())
                 ));
         // 3️⃣ meetingListResponses에 planList 추가
         for (MeetingListResponseV2 response : meetingListResponses) {
             response.setPlanList(planMap.getOrDefault(response.getMeetingId(), new ArrayList<>()));
         }
-        
+
         long meetingCount = Optional.ofNullable(
                 queryFactory
                         .select(meeting.count())


### PR DESCRIPTION
## 📌 작업 내용 (필수)
- 프론트엔드 개발자님 및 다자이너님의 요청으로 기존 모임 목록 조회 시 3개씩 반환하던 일정 목록을 4개씩 반환하도록 수정하였습니다.
- 모임 목록 조회 시 함께 반환되는 일정 데이터는 불필요한 데이터는 제거하고 필요한 데이터만 반환되도록 수정하였습니다.

<br/>

## 🌱 반영 브랜치
- `refactor/meeting-list-101` -> `dev`
- close #101 

<br/>
