### PR TITLE
[Test] 로그인 실패 케이스 테스트

### DIFF
--- a/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
+++ b/src/main/java/com/wemo/backend/domain/auth/JwtTokenProvider.java
@@ -142,7 +142,7 @@ public class JwtTokenProvider {
                 log.info("유효한 refreshToken입니다.");
                 return true;
             } else {
-                log.warn("DB에 해당 refreshToken이 존재하지 않습니다.");
+                log.warn("Redis에 해당 refreshToken이 존재하지 않습니다.");
             }
         } catch (TokenExpiredException e) {
             log.warn("refreshToken이 만료되었습니다.: {}", e.getMessage());

--- a/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuth.java
@@ -10,6 +10,6 @@ public interface UserAuth {
 
     String saveRefreshTokenToRedis(User user);
 
-    void generateHeaderTokens(User user, HttpServletRequest request, HttpServletResponse response);
+    void generateCookieTokens(User user, HttpServletRequest request, HttpServletResponse response);
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
+++ b/src/main/java/com/wemo/backend/domain/auth/UserAuthImpl.java
@@ -53,7 +53,7 @@ public class UserAuthImpl implements UserAuth {
      * @param user 유저 객체
      */
     @Override
-    public void generateHeaderTokens(User user, HttpServletRequest request, HttpServletResponse response) {
+    public void generateCookieTokens(User user, HttpServletRequest request, HttpServletResponse response) {
 
         String accessToken = getAccessToken(user);
         String refreshToken = saveRefreshTokenToRedis(user);

--- a/src/main/java/com/wemo/backend/domain/auth/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/repository/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package com.wemo.backend.domain.auth.token.repository;
 
 import com.wemo.backend.domain.auth.token.entity.RefreshToken;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class RefreshTokenRepository {
@@ -27,9 +29,16 @@ public class RefreshTokenRepository {
      */
     public void save(final RefreshToken refreshToken) {
 
+        log.info("refreshToken 저장메서드 호출");
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        valueOperations.set(refreshToken.refreshToken(), refreshToken.email());
-        redisTemplate.expire(refreshToken.refreshToken(), REFRESH_TOKEN_EXPIRATION, TimeUnit.MILLISECONDS); // TTL 설정
+        log.info("refreshToken.email() : {}", refreshToken.email());
+
+        // refreshToken을 key, 이메일을 value로 저장
+        valueOperations.set(refreshToken.refreshToken(), refreshToken.email(), REFRESH_TOKEN_EXPIRATION, TimeUnit.MILLISECONDS);
+
+        // 저장 후 확인
+        String storedValue = valueOperations.get(refreshToken.refreshToken());
+        log.info("✅ Redis 저장 완료 : {}", storedValue);
     }
 
     /**
@@ -38,7 +47,7 @@ public class RefreshTokenRepository {
      * @param refreshToken 유저 정보를 찾을 refreshToken
      * @return refreshToken과 관련된 유저 정보를 담은 Optional refreshToken
      */
-    public Optional<RefreshToken> findByEmail(final String refreshToken) {
+    public Optional<RefreshToken> findByRefreshToken(final String refreshToken) {
 
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
         String email = valueOperations.get(refreshToken);
@@ -62,8 +71,28 @@ public class RefreshTokenRepository {
      * @param refreshToken refreshToken 객체
      */
     public void delete(RefreshToken refreshToken) {
-        // Redis에서 해당 refreshToken 키 삭제
+
         redisTemplate.delete(refreshToken.refreshToken());
+    }
+
+    public Optional<RefreshToken> findByEmail(String email) {
+
+        log.info("findByEmail 호출");
+
+        // 이메일을 키로 사용하여 Redis에서 값 조회
+        String refreshTokenValue = redisTemplate.opsForValue().get("email:" + email);
+
+        log.info("email : {}", email);
+        log.info("refreshTokenValue: {}", refreshTokenValue);
+
+        // 값이 존재하는 경우, RefreshToken 객체로 변환하여 반환
+        if (refreshTokenValue != null) {
+            // refreshToken은 불변 객체이므로 생성자에 값만 전달하면 됩니다.
+            return Optional.of(new RefreshToken(refreshTokenValue, email));
+        }
+
+        // 값이 존재하지 않으면 Optional.empty() 반환
+        return Optional.empty();
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
+++ b/src/main/java/com/wemo/backend/domain/auth/token/service/RefreshTokenManager.java
@@ -9,6 +9,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
@@ -16,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import static com.wemo.backend.global.exception.ErrorCode.INVALID_REFRESH_TOKEN;
 
@@ -28,6 +32,11 @@ public class RefreshTokenManager {
     private final JwtTokenUtils jwtTokenUtils;
     private final AccessTokenManager accessTokenManager;
 
+    @Value("${REFRESH_TOKEN_EXPIRATION}")
+    private int REFRESH_TOKEN_EXPIRATION;
+
+    private final RedisTemplate<String, String> redisTemplate;
+
     /**
      * JWT refreshToken 생성 및 저장
      *
@@ -39,14 +48,33 @@ public class RefreshTokenManager {
 
         String refreshToken = jwtTokenUtils.generateRefreshToken(email);
 
-        Optional<RefreshToken> existingToken = refreshTokenRepository.findByEmail(email);
+        Optional<RefreshToken> existingToken = refreshTokenRepository.findByRefreshToken(email);
 
         if (existingToken.isPresent()) {
+            log.info("existingToken : {}", existingToken.get());
             refreshTokenRepository.delete(existingToken.get());
-            log.info("기존에 존재하는 refreshToken 삭제 완료");
+            log.info("기존에 존재하는 refreshToken DB에서 삭제 완료");
         }
 
+        redisTemplate.delete("email:" + email);
+        log.info("기존에 존재하는 refreshToken DB에서 삭제 완료");
+
+        // 새 refreshToken DB에 저장
         refreshTokenRepository.save(new RefreshToken(refreshToken, email));
+
+        // Redis에서 기존에 발급된 refreshToken 있는지 확인
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String existingRedisToken = valueOperations.get(refreshToken);
+
+        // 기존 refreshToken이 Redis에 존재하면 삭제
+        if (existingRedisToken != null && !existingRedisToken.isEmpty()) {
+            redisTemplate.delete(existingRedisToken);
+            log.info("기존 refreshToken Redis에서 삭제 완료");
+        }
+
+        // 새 refreshToken을 Redis에 저장
+        redisTemplate.opsForValue().set(refreshToken, email, REFRESH_TOKEN_EXPIRATION, TimeUnit.MILLISECONDS);
+        log.info("새로운 refreshToken Redis에 저장 완료");
 
         return refreshToken;
     }
@@ -59,7 +87,7 @@ public class RefreshTokenManager {
      */
     public RefreshToken getRefreshToken(String refreshToken) {
 
-        return refreshTokenRepository.findByEmail(refreshToken).orElseThrow(
+        return refreshTokenRepository.findByRefreshToken(refreshToken).orElseThrow(
                 () -> new CustomException(INVALID_REFRESH_TOKEN)
         );
 
@@ -73,7 +101,7 @@ public class RefreshTokenManager {
      */
     public String validateRefreshToken(String refreshToken) {
 
-        Optional<RefreshToken> token = refreshTokenRepository.findByEmail(refreshToken);
+        Optional<RefreshToken> token = refreshTokenRepository.findByRefreshToken(refreshToken);
         return token.map(RefreshToken::email).orElse(null);
     }
 
@@ -144,23 +172,24 @@ public class RefreshTokenManager {
 
     public void deleteRefreshTokenInCookie(HttpServletResponse response) {
 
-        ResponseCookie cookie = ResponseCookie.from("Refresh-Token", null)
-                .maxAge(0)
+        // "Refresh-Token" 쿠키 삭제를 위한 설정
+        ResponseCookie cookie = ResponseCookie.from("Refresh-Token", "")
+                .maxAge(0)  // 유효기간을 0으로 설정해서 삭제
                 .sameSite("None")
                 .secure(true)
                 .httpOnly(true)
                 .path("/")
                 .build();
 
+        // 쿠키 삭제를 위한 헤더 추가
         response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
 
         log.info("Refresh-Token 쿠키 삭제 완료");
-
     }
 
     public boolean existsByEmail(String email) {
 
-        return refreshTokenRepository.findByEmail(email).isPresent();
+        return refreshTokenRepository.findByRefreshToken(email).isPresent();
     }
 
 }

--- a/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/lightning/repository/querydsl/LightningCursorQueryDslImpl.java
@@ -124,7 +124,7 @@ public class LightningCursorQueryDslImpl implements LightningCursorQueryDsl {
                 double radiusInMeters = radius * 1000; // km → m 변환
 
                 NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
-                        "ST_Distance_Sphere(point({0}, {1}), point(plan.longitude, plan.latitude))",
+                        "ST_Distance_Sphere(point({0}, {1}), point(lightning.longitude, lightning.latitude))",
                         longitude, latitude);
 
                 condition = condition.and(distance.loe(radiusInMeters));

--- a/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
+++ b/src/main/java/com/wemo/backend/domain/plan/repository/querydsl/PlanCursorQueryDslImpl.java
@@ -5,6 +5,7 @@ import com.querydsl.core.types.ConstructorExpression;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wemo.backend.domain.image.entity.Image;
 import com.wemo.backend.domain.lightning.repository.querydsl.LightningCursorQueryDslImpl;
@@ -21,7 +22,6 @@ import java.util.Optional;
 
 import static com.wemo.backend.domain.attendance.entity.QAttendance.attendance;
 import static com.wemo.backend.domain.image.entity.QImage.image;
-import static com.wemo.backend.domain.lightning.repository.querydsl.LightningCursorQueryDslImpl.buildAddressFilter;
 import static com.wemo.backend.domain.like.entity.QLikes.likes;
 import static com.wemo.backend.domain.meeting.entity.QMeeting.meeting;
 import static com.wemo.backend.domain.plan.entity.QPlan.plan;
@@ -211,6 +211,23 @@ public class PlanCursorQueryDslImpl implements PlanCursorQueryDsl {
 
         // 위치 기반 필터링 추가 (필터가 없는 경우)
         return buildAddressFilter(province, district, latitude, longitude, radius, booleanExpression);
+    }
+
+    public static BooleanExpression buildAddressFilter(String province, String district, Double latitude, Double longitude, Double radius, BooleanExpression condition) {
+
+        if ((province == null || province.isEmpty()) && (district == null || district.isEmpty())) {
+            if (latitude != null && longitude != null && radius != null) {
+                double radiusInMeters = radius * 1000; // km → m 변환
+
+                NumberExpression<Double> distance = Expressions.numberTemplate(Double.class,
+                        "ST_Distance_Sphere(point({0}, {1}), point(plan.longitude, plan.latitude))",
+                        longitude, latitude);
+
+                condition = condition.and(distance.loe(radiusInMeters));
+            }
+        }
+
+        return condition;
     }
 
     static BooleanExpression buildFilterForPlanList(String query, String province, String district, String startDate, String endDate, Long categoryId) {

--- a/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/wemo/backend/domain/user/service/UserServiceImpl.java
@@ -96,7 +96,7 @@ public class UserServiceImpl implements UserService {
         User user = userReader.getUser(signinRequest.getEmail(), signinRequest.getPassword());
         log.info("사용자 {} 로그인 성공", user.getEmail());
 
-        userAuth.generateHeaderTokens(user, request, response);
+        userAuth.generateCookieTokens(user, request, response);
     }
 
     /**
@@ -109,15 +109,25 @@ public class UserServiceImpl implements UserService {
     public String signout(HttpServletRequest request, HttpServletResponse response) {
 
         String refreshToken = getTokenFromCookie(request, "Refresh-Token");
+        log.info("Extracted refreshToken: {}", refreshToken);
+        // ✅ refreshToken이 null이면 바로 종료
+        if (refreshToken == null) {
+            log.warn("로그아웃 실패: RefreshToken이 존재하지 않음");
+            return "로그아웃 실패: RefreshToken이 존재하지 않음";
+        }
 
         // accessToken 검증 무효화 처리
         accessTokenManager.deleteAccessTokenInCookie(response);
 
         // refreshToken 삭제
         RefreshToken findRefreshToken = refreshTokenManager.getRefreshToken(refreshToken);
+        if (findRefreshToken == null) {
+            log.warn("로그아웃 실패: 해당 RefreshToken이 존재하지 않음");
+            return "로그아웃 실패: 해당 RefreshToken이 존재하지 않음";
+        }
         refreshTokenManager.deleteRefreshTokenInCookie(response);
         refreshTokenRepository.delete(findRefreshToken);
-        log.info("refreshToken 삭제 완료");
+        log.info("Redis에서 refreshToken 삭제 완료");
 
         return "로그아웃 성공";
     }

--- a/src/test/java/com/wemo/backend/domain/user/service/UserServiceImplTest.java
+++ b/src/test/java/com/wemo/backend/domain/user/service/UserServiceImplTest.java
@@ -7,16 +7,15 @@ import com.wemo.backend.domain.user.entity.LoginType;
 import com.wemo.backend.domain.user.entity.User;
 import com.wemo.backend.domain.user.repository.UserRepository;
 import com.wemo.backend.global.exception.CustomException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import jakarta.transaction.Transactional;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
-import static com.wemo.backend.global.exception.ErrorCode.EMAIL_ALREADY_IN_USE;
+import static com.wemo.backend.global.exception.ErrorCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 @ActiveProfiles("test")
@@ -35,15 +34,15 @@ class UserServiceImplTest {
     @Autowired
     private PasswordEncoder passwordEncoder;
 
-    @Autowired
-    private HttpServletResponse response;
+    private MockHttpServletRequest request;
 
-    @Autowired
-    private HttpServletRequest request;
+    private MockHttpServletResponse response;
 
     @BeforeEach
-    @Transactional
     void setUp() {
+
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
 
         userRepository.deleteAll();
 
@@ -60,7 +59,6 @@ class UserServiceImplTest {
     }
 
     @AfterEach
-    @Transactional
     void tearDown() {
 
         userRepository.deleteAll();
@@ -71,8 +69,7 @@ class UserServiceImplTest {
     class Success {
 
         @Test
-        @DisplayName("회원 가입 해피 케이스 테스트")
-        @Transactional
+        @DisplayName("회원 가입에 성공합니다.")
         void signup_Success() {
             // given
             UserCreateRequest request = new UserCreateRequest(
@@ -91,12 +88,11 @@ class UserServiceImplTest {
         }
 
         @Test
-        @DisplayName("로그인 해피 케이스 테스트")
+        @DisplayName("로그인에 성공합니다.")
         void signin_Success() {
             // given
             String email = "existing@example.com";
             String password = "password123";
-
             SigninRequest signinRequest = new SigninRequest(email, password);
 
             // when
@@ -106,15 +102,87 @@ class UserServiceImplTest {
             assertTrue(refreshTokenManager.existsByEmail(email)); // ✅ refreshToken 저장 여부 확인
         }
 
+//        @Test
+//        @DisplayName("로그아웃에 성공합니다.")
+//        void logout_Success() {
+//            // given
+//            String email = "existing@example.com";
+//            SigninRequest signinRequest = new SigninRequest(email, "password123");
+//
+//            // 로그인하여 토큰 발급
+//            userService.signin(signinRequest, request, response);
+//
+//            // 로그인 후 발급된 refreshToken을 쿠키로 가져오기
+//            Cookie accessTokenCookie = response.getCookie("accessToken");
+//            Cookie refreshTokenCookie = response.getCookie("Refresh-Token");
+//
+//            // when
+//            // `request` 객체에 `Refresh-Token` 쿠키를 직접 추가
+//            request.setCookies(new Cookie("accessToken", accessTokenCookie.getValue())); // 쿠키 주입
+//            request.setCookies(new Cookie("Refresh-Token", refreshTokenCookie.getValue())); // 쿠키 주입
+//
+//            // 로그아웃 실행
+//            userService.signout(request, response);
+//
+//            // then
+//            // 쿠키가 만료되었는지 확인
+//            Cookie accessTokenCookieAfterLogout = response.getCookie("accessToken");
+//            Cookie refreshTokenCookieAfterLogout = response.getCookie("Refresh-Token");
+//
+//            assertNotNull(accessTokenCookieAfterLogout);
+//            assertNotNull(refreshTokenCookieAfterLogout);
+//
+//            // 쿠키 만료 처리
+//            accessTokenCookieAfterLogout.setMaxAge(0);  // 만료 설정
+//            refreshTokenCookieAfterLogout.setMaxAge(0);  // 만료 설정
+//
+//            assertEquals(0, accessTokenCookieAfterLogout.getMaxAge()); // accessToken 만료 확인
+//            assertEquals(0, refreshTokenCookieAfterLogout.getMaxAge()); // Refresh-Token 만료 확인
+//
+//            // Redis에서 refreshToken이 삭제되었는지 확인
+//            assertFalse(refreshTokenManager.existsByEmail(email));
+//        }
+//
+//        @Test
+//        @DisplayName("로그아웃에 성공하면 RefreshToken이 삭제되고 AccessToken 쿠키가 만료됨")
+//        void logout_Success_cookie() {
+//            // given (로그인 상태에서 로그아웃 요청)
+//            String email = "existing@example.com";
+//            SigninRequest signinRequest = new SigninRequest(email, "password123");
+//
+//            MockHttpServletRequest mockRequest = new MockHttpServletRequest();
+//            MockHttpServletResponse mockResponse = new MockHttpServletResponse();
+//
+//            userService.signin(signinRequest, mockRequest, mockResponse); // 로그인 진행
+//
+//            // 로그아웃 전에 email이 정상적으로 있는지 확인
+//            assertNotNull(email, "로그아웃 시 email 값이 null이면 안됩니다!");
+//
+//            // when (로그아웃 실행)
+//            userService.signout(mockRequest, mockResponse);
+//
+//            // then (Redis에서 RefreshToken이 삭제되었는지 확인)
+//            assertFalse(refreshTokenManager.existsByEmail(email));
+//
+//            // 그리고 response에서 AccessToken 쿠키가 만료되었는지 확인
+//            Cookie[] cookies = mockResponse.getCookies();
+//            Cookie accessTokenCookie = Arrays.stream(cookies)
+//                    .filter(cookie -> "accessToken".equals(cookie.getName()))
+//                    .findFirst()
+//                    .orElse(null);
+//
+//            assertNotNull(accessTokenCookie);
+//            assertEquals(0, accessTokenCookie.getMaxAge()); // ✅ 만료된 쿠키인지 확인
+//        }
+
     }
 
     @Nested
     @DisplayName("Failure")
     class Failure {
         @Test
-        @DisplayName("회원 가입 이메일 중복 예외 케이스 테스트")
-        @Transactional
-        void signup_Failure() {
+        @DisplayName("회원 가입 시 기존에 존재하는 이메일로 가입하는 경우 실패합니다.")
+        void signup_Failure_duplicate_email() {
             // given
             UserCreateRequest request = new UserCreateRequest(
                     "existing@example.com",
@@ -127,9 +195,37 @@ class UserServiceImplTest {
             // when & then
             CustomException exception = assertThrows(CustomException.class, () -> userService.signup(request));
             assertEquals(EMAIL_ALREADY_IN_USE, exception.getErrorCode());
+        }
 
+        @Test
+        @DisplayName("가입되지 않은 아이디로 로그인 시 실패합니다.")
+        void signin_Failure_user_not_exist() {
+            // given
+            SigninRequest signinRequest = new SigninRequest(
+                    "newUser@example.com",
+                    "password"
+            );
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.signin(signinRequest, request, response));
+            assertEquals(USER_NOT_FOUND, exception.getErrorCode());
+        }
+
+        @Test
+        @DisplayName("등록된 비밀번호와 일치하지 않는 경우 로그인에 실패합니다.")
+        void signin_Failure_validPassword() {
+            // given
+            SigninRequest signinRequest = new SigninRequest(
+                    "existing@example.com",
+                    "anotherPassword"
+            );
+
+            // when & then
+            CustomException exception = assertThrows(CustomException.class, () -> userService.signin(signinRequest, request, response));
+            assertEquals(INVALID_PASSWORD, exception.getErrorCode());
         }
 
     }
+
 
 }


### PR DESCRIPTION
## 📌 작업 내용 (필수)

### 🔄 변경된 내용  
- **RefreshToken 저장 방식 수정**  
- **번개 모임 목록 조회 시 위치 기반 필터링 오류 수정**  

### ✨ 추가된 내용  
- **로그인 실패 케이스 테스트 추가**  
  - 가입되지 않은 아이디로 로그인 시 예외 반환  
  - 등록된 비밀번호와 일치하지 않을 시 예외 반환  

<br>

## 🌱 반영 브랜치  
- `test/user-123` -> `dev`  
- close #  

<br>

## 🔥 트러블 슈팅 (선택)  
- 테스트용 Redis 서버를 연결하지 않아 **RefreshToken 저장 여부 확인에 어려움** 발생  
- Mock 객체 사용을 고려했지만, **실제 객체와 혼재되어 테스트 실패**  
- `@TestRedisConfig` 파일을 생성해 테스트 환경에서 Redis 연결을 시도했으나,  
  기존 클래스가 **인터페이스 구현체로 되어 있어야 사용 가능**한 문제 발생  
- **다른 해결 방법 고민 중**  
